### PR TITLE
Add experiment which calls LLVM from Python

### DIFF
--- a/xrcf/tests/calculate.py
+++ b/xrcf/tests/calculate.py
@@ -3,85 +3,82 @@ import os
 import sys
 from timeit import timeit
 
+length = 256
 
-class Vec16x16(Structure):
-    _fields_ = [("values", c_int16 * 16)]
+
+class Vec8x16(Structure):
+    _fields_ = [("values", c_int16 * length)]
+
+    def __init__(self, value=0):
+        super().__init__()
+        for i in range(length):
+            self.values[i] = value
 
     def __repr__(self):
-        return f"Vec16x16({list(self.values)})"
+        return f"Vec{length}x16({list(self.values)})"
 
 
-ll = """
-define i32 @calculate(i32 %a, i32 %b) #0 {
-  %1 = mul i32 %a, %b
-  %2 = add i32 %1, 43
-  ret i32 %2
-}
+def ll():
+    return (
+        """
+    define i32 @calculate(i32 %a, i32 %b) #0 {
+    %1 = mul i32 %a, %b
+    %2 = add i32 %1, 43
+    ret i32 %2
+    }
+    """
+        + f"""
+    define void @calc_vec(<{length} x i16>* %o, <{length} x i16>* %a, <{length} x i16>* %b) #0 {{
+    %1 = load <{length} x i16>, <{length} x i16>* %a, align 16
+    %2 = load <{length} x i16>, <{length} x i16>* %b, align 16
+    %3 = add <{length} x i16> %1, %2
+    store <{length} x i16> %3, <{length} x i16>* %o, align 16
+    ret void
+    }}
 
-define void @calc_vec(<16 x i16>* %o, <16 x i16>* %a, <16 x i16>* %b) #0 {
-  %1 = load <16 x i16>, <16 x i16>* %a, align 32
-  %2 = load <16 x i16>, <16 x i16>* %b, align 32
-  %3 = add <16 x i16> %1, %2
-  store <16 x i16> %3, <16 x i16>* %o, align 32
-  ret void
-}
-
-attributes #0 = { nounwind }
-"""
+    attributes #0 = {{ nounwind "target-features"="neon" }}
+    """
+    )
 
 
 def load_lib():
-    res = os.system(f"echo '{ll}' | clang -x ir - -shared -o tmp.so")
+    res = os.system(f"echo '{ll()}' | clang -x ir - -shared -o tmp.so")
     if res != 0:
         sys.exit(res)
 
     lib = CDLL("./tmp.so")
     lib.calculate.argtypes = [c_int, c_int]
     lib.calculate.restype = c_int
-    lib.calc_vec.argtypes = [POINTER(Vec16x16), POINTER(Vec16x16), POINTER(Vec16x16)]
+    lib.calc_vec.argtypes = [POINTER(Vec8x16), POINTER(Vec8x16), POINTER(Vec8x16)]
     lib.calc_vec.restype = None
     return lib
 
 
 lib = load_lib()
 result = lib.calculate(1, 2)
-secs = lib.calculate(1, 2)
 print(f"calculate: {result}")
 
 number = 100_000
 
-a = Vec16x16()
-b = Vec16x16()
-for i in range(1, 8):
-    a.values[i] = 1
-    b.values[i] = 2
-for i in range(8, 16):
-    a.values[i] = 3
-    b.values[i] = 4
-o = Vec16x16()
-secs = timeit(lambda: lib.calc_vec(byref(o), byref(a), byref(b)), number=number)
-print(f"calc_vec: {o}")
-print(f"calc_vec: {secs}")
-
 
 def calc_vec_py(o, a, b):
-    for i in range(1, 8):
-        o.values[i] = a.values[i] + b.values[i]
-    for i in range(8, 16):
+    for i in range(length):
         o.values[i] = a.values[i] + b.values[i]
     return o
 
 
-a = Vec16x16()
-for i in range(1, 8):
-    a.values[i] = 1
-    b.values[i] = 2
-for i in range(8, 16):
-    a.values[i] = 3
-    b.values[i] = 4
-o = Vec16x16()
+a = Vec8x16(1)
+b = Vec8x16(2)
+o = Vec8x16(0)
 py_secs = timeit(lambda: calc_vec_py(o, a, b), number=number)
 print(f"calc_vec_py: {o}")
 print(f"calc_vec_py: {py_secs}")
+
+a = Vec8x16(1)
+b = Vec8x16(2)
+o = Vec8x16()
+secs = timeit(lambda: lib.calc_vec(byref(o), byref(a), byref(b)), number=number)
+print(f"calc_vec: {o}")
+print(f"calc_vec: {secs}")
 
 print(f"Difference: {py_secs / secs}")


### PR DESCRIPTION
Essentially, the idea of Jax, Triton, Mojo, NVIDIA/cuda-python, and Core ML is to support new hardware operations like SIMD/SME. Languages do not evolve fast enough to keep up with these new operations.

This PR experiments with calling LLVM directly from Python. This is like aforementioned projects where the Python code does the pre- and post-processing and the actual kernel is written in a DSL.

A long-term goal of this could be to run a faster matmul via MLIR/LLVM than is possible in native Python. Next, a compiler can be built that makes writing the MLIR/LLVM less cumbersome.

For example, this program runs a simple calculation function via LLVM:

```python
from ctypes import CDLL, c_int
import os
import sys

ll = """
define i32 @calculate(i32 %a, i32 %b) #0 {
    %1 = mul i32 %a, %b
    %2 = add i32 %1, 43
    ret i32 %2
}

attributes #0 = { nounwind }
"""

def load_lib():
    res = os.system(f"echo '{ll}' | clang -x ir - -shared -o tmp.so")
    if res != 0:
        sys.exit(res)

    lib = CDLL("./tmp.so")
    lib.calculate.argtypes = [c_int, c_int]
    lib.calculate.restype = c_int
    return lib


lib = load_lib()
result = lib.calculate(1, 2)
print(f"Result: {result}")
```

EDIT: Probably better to focus on allowing people to write their own transformations and not on speed. The speed space is too crowded already, see also microsoft/BitNet