### PR TITLE
Allow lowering if statement from ArnoldC

### DIFF
--- a/arnoldc/README.md
+++ b/arnoldc/README.md
@@ -1,4 +1,4 @@
 # arnoldc
 
-This directory contains an example compiler that can compile and run a small program in the [ArnoldC language](https://github.com/lhartikk/ArnoldC).
+This directory contains an example compiler built using xrcf that can compile and run a small program in the [ArnoldC language](https://github.com/lhartikk/ArnoldC).
 See [this blog post](https://xrcf.org/blog/basic-arnoldc/) for more information.

--- a/arnoldc/src/arnold.rs
+++ b/arnoldc/src/arnold.rs
@@ -112,8 +112,9 @@ impl<T: ParserDispatch> ArnoldParse for Parser<T> {
 
 /// `IT'S SHOWTIME`
 ///
-/// We do not immediately parse this into some `arnold::FuncOp` in order to
-/// apply a rewrite first:
+/// We do not immediately parse this into some `arnold::FuncOp` since the
+/// rewrite should not only change the op but also return a zero for the status
+/// code.
 ///
 /// ```arnoldc
 /// ITS SHOWTIME {

--- a/arnoldc/src/arnold.rs
+++ b/arnoldc/src/arnold.rs
@@ -334,16 +334,22 @@ impl Parse for IfOp {
         parser.parse_arnold_operation_name_into(name, &mut operation)?;
         parser.parse_op_operand_into(parent.clone().unwrap(), TOKEN_KIND, &mut operation)?;
         let operation = Arc::new(RwLock::new(operation));
-        let mut op = IfOp {
+        let op = IfOp {
             operation: operation.clone(),
             then: None,
             els: None,
         };
         let op = Arc::new(RwLock::new(op));
         let then = parser.parse_region(op.clone())?;
+        let else_keyword = parser.expect(TokenKind::BareIdentifier)?;
+        if else_keyword.lexeme != "BULLSHIT" {
+            panic!("Expected BULLSHIT but got {}", else_keyword.lexeme);
+        }
+        let els = parser.parse_region(op.clone())?;
         let op_write = op.clone();
         let mut op_write = op_write.try_write().unwrap();
         op_write.then = Some(then);
+        op_write.els = Some(els);
         Ok(op)
     }
 }

--- a/arnoldc/src/arnold.rs
+++ b/arnoldc/src/arnold.rs
@@ -29,8 +29,8 @@ fn arnold_integer(value: u64) -> APInt {
     APInt::new(16, value, true)
 }
 
-fn arnold_attribute(value: u64) -> IntegerAttr {
-    let typ = IntegerType::new(16);
+fn arnold_attribute(value: u64, num_bits: u64) -> IntegerAttr {
+    let typ = IntegerType::new(num_bits);
     let value = arnold_integer(value);
     IntegerAttr::new(typ, value)
 }
@@ -66,9 +66,9 @@ impl<T: ParserDispatch> ArnoldParse for Parser<T> {
         let next_next = self.advance();
         let constant = format!("{} {}", next.lexeme, next_next.lexeme);
         let constant = if constant == "@NO PROBLEMO" {
-            arnold_attribute(1)
+            arnold_attribute(1, 1)
         } else if constant == "@I LIED" {
-            arnold_attribute(0)
+            arnold_attribute(0, 1)
         } else {
             return Err(anyhow::anyhow!("Unknown constant: {}", constant));
         };

--- a/arnoldc/src/arnold.rs
+++ b/arnoldc/src/arnold.rs
@@ -55,7 +55,6 @@ trait ArnoldParse {
 /// Tokenize an ArnoldC operation name.
 fn tokenize_arnoldc_name(name: &str) -> Vec<String> {
     let name = name.replace('\'', " \' ");
-    println!("name: {name}");
     name.split_whitespace().map(|s| s.to_string()).collect()
 }
 
@@ -135,8 +134,7 @@ pub struct BeginMainOp {
 
 impl Op for BeginMainOp {
     fn operation_name() -> OperationName {
-        // Removed the single quote to make it easier to handle.
-        OperationName::new("ITS SHOWTIME".to_string())
+        OperationName::new("IT'S SHOWTIME".to_string())
     }
     fn new(operation: Arc<RwLock<Operation>>) -> Self {
         BeginMainOp { operation }

--- a/arnoldc/src/main.rs
+++ b/arnoldc/src/main.rs
@@ -9,6 +9,7 @@ use clap::Command;
 use std::env::ArgsOs;
 use std::io::Read;
 use xrcf::convert::RewriteResult;
+use xrcf::init_subscriber;
 use xrcf::Passes;
 
 use crate::transform::parse_and_transform;
@@ -26,6 +27,9 @@ struct ArnoldcArgs {
     /// Compile the code
     #[arg(long, name = "compile")]
     compile: bool,
+    /// Print debug information
+    #[arg(long, name = "debug")]
+    debug: bool,
 }
 
 fn cli() -> Command {
@@ -53,10 +57,22 @@ fn passes_from_args(args: ArgsOs, matches: ArgMatches) -> Passes {
     }
 }
 
+fn init_tracing(level: tracing::Level) {
+    match init_subscriber(level) {
+        Ok(_) => (),
+        Err(_e) => (),
+    }
+}
+
 fn main() {
     let cli = cli();
     let args = std::env::args_os();
     let matches = cli.get_matches();
+    if matches.get_flag("debug") {
+        init_tracing(tracing::Level::DEBUG);
+    } else {
+        init_tracing(tracing::Level::INFO);
+    }
     let passes = passes_from_args(args, matches.clone());
 
     let input = matches.get_one::<String>("input").unwrap();

--- a/arnoldc/src/main.rs
+++ b/arnoldc/src/main.rs
@@ -34,17 +34,20 @@ fn cli() -> Command {
     cli
 }
 
+fn compile_passes() -> Vec<&'static str> {
+    vec![
+        "--convert-arnold-to-mlir",
+        "--convert-experimental-to-mlir",
+        "--convert-scf-to-cf",
+        "--convert-cf-to-llvm",
+        "--convert-func-to-llvm",
+        "--convert-mlir-to-llvmir",
+    ]
+}
+
 fn passes_from_args(args: ArgsOs, matches: ArgMatches) -> Passes {
     if matches.get_flag("compile") {
-        let args = vec![
-            "--convert-arnold-to-mlir",
-            "--convert-experimental-to-mlir",
-            "--convert-scf-to-cf",
-            "--convert-cf-to-llvm",
-            "--convert-func-to-llvm",
-            "--convert-mlir-to-llvmir",
-        ];
-        Passes::from_convert_vec(args)
+        Passes::from_convert_vec(compile_passes())
     } else {
         Passes::from_convert_args(args)
     }

--- a/arnoldc/src/transform.rs
+++ b/arnoldc/src/transform.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use std::sync::RwLock;
 use xrcf::convert::Pass;
 use xrcf::convert::RewriteResult;
-use xrcf::ir::spaces;
 use xrcf::ir::Block;
 use xrcf::ir::Op;
 use xrcf::ir::Type;
@@ -313,8 +312,8 @@ mod tests {
         .trim();
         let expected = indoc! {r#"
         func.func @main() -> i32 {
-          %false = arith.constant false
-          scf.if %false {
+          %x = arith.constant 0 : i16
+          scf.if %x {
             experimental.printf("x was true")
           } else {
             experimental.printf("x was false")
@@ -326,6 +325,6 @@ mod tests {
         .trim();
         let (module, actual) = test_transform(src, flags());
         Tester::verify(module);
-        Tester::check_lines_exact(expected, actual.trim(), Location::caller());
+        Tester::check_lines_contain(actual.trim(), expected, Location::caller());
     }
 }

--- a/arnoldc/src/transform.rs
+++ b/arnoldc/src/transform.rs
@@ -325,6 +325,6 @@ mod tests {
         .trim();
         let (module, actual) = test_transform(src, flags());
         Tester::verify(module);
-        // Tester::check_lines_contain(actual.trim(), expected, Location::caller());
+        Tester::check_lines_contain(actual.trim(), expected, Location::caller());
     }
 }

--- a/arnoldc/src/transform.rs
+++ b/arnoldc/src/transform.rs
@@ -274,7 +274,7 @@ mod tests {
         let expected = indoc! {r#"
         module {
           func.func @main() -> i32 {
-            %x = arith.constant 1 : i16
+            %x = arith.constant 1 : i1
             experimental.printf("x: ")
             experimental.printf("%d", %x)
             %0 = arith.constant 0 : i32
@@ -308,7 +308,7 @@ mod tests {
         .trim();
         let expected = indoc! {r#"
         func.func @main() -> i32 {
-          %x = arith.constant 0 : i16
+          %x = arith.constant 0 : i1
           scf.if %x {
             experimental.printf("x was true")
           } else {

--- a/arnoldc/src/transform.rs
+++ b/arnoldc/src/transform.rs
@@ -325,6 +325,6 @@ mod tests {
         .trim();
         let (module, actual) = test_transform(src, flags());
         Tester::verify(module);
-        Tester::check_lines_contain(actual.trim(), expected, Location::caller());
+        // Tester::check_lines_contain(actual.trim(), expected, Location::caller());
     }
 }

--- a/arnoldc/src/transform.rs
+++ b/arnoldc/src/transform.rs
@@ -325,6 +325,10 @@ mod tests {
 
         let expected = indoc! {r#"
         define i32 @main() {
+        
+        br i1 0, label %bb1, label %bb2
+
+        ret i32 0
         "#}
         .trim();
         let passes = compile_passes();

--- a/arnoldc/src/transform.rs
+++ b/arnoldc/src/transform.rs
@@ -133,6 +133,7 @@ pub fn parse_and_transform(src: &str, passes: &Passes) -> Result<RewriteResult> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::compile_passes;
     use indoc::indoc;
     use std::panic::Location;
     use tracing;
@@ -248,12 +249,7 @@ mod tests {
         Tester::check_lines_exact(expected, actual.trim(), Location::caller());
         Tester::verify(module);
 
-        let passes = vec![
-            "--convert-arnold-to-mlir",
-            "--convert-experimental-to-mlir",
-            "--convert-func-to-llvm",
-            "--convert-mlir-to-llvmir",
-        ];
+        let passes = compile_passes();
         let (module, actual) = test_transform(src, passes);
         Tester::verify(module);
         assert!(actual.contains("declare i32 @printf(ptr)"));
@@ -302,9 +298,9 @@ mod tests {
         YOU SET US UP @I LIED
 
         BECAUSE I'M GOING TO SAY PLEASE x
-        TALK TO THE HAND "x was true"
+          TALK TO THE HAND "x was true"
         BULLSHIT
-        TALK TO THE HAND "x was false"
+          TALK TO THE HAND "x was false"
         YOU HAVE NO RESPECT FOR LOGIC
 
         YOU HAVE BEEN TERMINATED
@@ -324,6 +320,15 @@ mod tests {
         "#}
         .trim();
         let (module, actual) = test_transform(src, flags());
+        Tester::verify(module);
+        Tester::check_lines_contain(actual.trim(), expected, Location::caller());
+
+        let expected = indoc! {r#"
+        define i32 @main() {
+        "#}
+        .trim();
+        let passes = compile_passes();
+        let (module, actual) = test_transform(src, passes);
         Tester::verify(module);
         Tester::check_lines_contain(actual.trim(), expected, Location::caller());
     }

--- a/arnoldc/src/transform.rs
+++ b/arnoldc/src/transform.rs
@@ -101,7 +101,7 @@ impl TransformDispatch for ArnoldTransformDispatch {
 ///
 /// This mostly adds braces to make the structure of the code more clear. This
 /// could have been done in the xrcf parser, but it's moved here to keep the
-/// logic more separate.
+/// logic separated (i.e., to make it easier to understand the code).
 fn preprocess(src: &str) -> String {
     let mut result = String::new();
     for line in src.lines() {

--- a/xrcf-bin/src/main.rs
+++ b/xrcf-bin/src/main.rs
@@ -3,6 +3,7 @@ use clap::Args;
 use clap::Command;
 use std::io::Read;
 use xrcf::convert::RewriteResult;
+use xrcf::init_subscriber;
 use xrcf::parser::DefaultParserDispatch;
 use xrcf::parser::Parser;
 use xrcf::transform;
@@ -16,6 +17,9 @@ struct XRCFArgs {
     /// The input file (- is interpreted as stdin)
     #[arg(default_value = "-")]
     input: String,
+    /// Print debug information
+    #[arg(long, name = "debug")]
+    debug: bool,
 }
 
 fn cli() -> Command {
@@ -39,11 +43,23 @@ fn parse_and_transform(src: &str, passes: &Passes) -> String {
     result
 }
 
+fn init_tracing(level: tracing::Level) {
+    match init_subscriber(level) {
+        Ok(_) => (),
+        Err(_e) => (),
+    }
+}
+
 fn main() {
     let cli = cli();
     let args = std::env::args_os();
     let passes = Passes::from_convert_args(args);
     let matches = cli.get_matches();
+    if matches.get_flag("debug") {
+        init_tracing(tracing::Level::DEBUG);
+    } else {
+        init_tracing(tracing::Level::INFO);
+    }
 
     let input = matches.get_one::<String>("input").unwrap();
 

--- a/xrcf/script/release.sh
+++ b/xrcf/script/release.sh
@@ -17,14 +17,22 @@ TAGNAME="v$VERSION"
 echo "TAGNAME: $TAGNAME"
 
 echo ""
+echo "ENSURE CHANGELOG.md IS UP-TO-DATE"
+echo ""
 echo "ENSURE YOU ARE ON THE MAIN BRANCH"
 echo ""
 
 NOTES="See [CHANGELOG.md](https://github.com/rikhuijzer/xrcf/blob/main/CHANGELOG.md) for more information."
 
-read -p "Creating a new tag, which WILL TRIGGER A RELEASE with the following release notes: \"$NOTES\". Are you sure? [y/N]" -n 1 -r
-if [[ $REPLY =~ ^[Yy]$ ]]; then
+read -p "Creating a new tag, which WILL TRIGGER A RELEASE with the following release notes: \"$NOTES\". Are you sure? Type YES to continue. " REPLY
+
+if [[ $REPLY == "YES" ]]; then
     echo ""
     git tag -a $TAGNAME -m "$NOTES"
     git push origin $TAGNAME
+    exit 0
+else
+    echo ""
+    echo "Did not receive YES, aborting"
+    exit 1
 fi

--- a/xrcf/script/release.sh
+++ b/xrcf/script/release.sh
@@ -10,6 +10,8 @@ set -e
 # trigger new workflows.
 # "This prevents you from accidentally creating recursive workflow runs."
 
+echo "CREATING A RELEASE WITH:"
+
 METADATA="$(cargo metadata --format-version=1 --no-deps)"
 VERSION="$(echo $METADATA | jq -r '.packages[0].version')"
 echo "VERSION: $VERSION"

--- a/xrcf/script/release.sh
+++ b/xrcf/script/release.sh
@@ -14,12 +14,12 @@ echo "CREATING A RELEASE WITH:"
 
 METADATA="$(cargo metadata --format-version=1 --no-deps)"
 VERSION="$(echo $METADATA | jq -r '.packages[0].version')"
-echo "VERSION: $VERSION"
+echo "VERSION $VERSION"
 TAGNAME="v$VERSION"
-echo "TAGNAME: $TAGNAME"
+echo "TAGNAME $TAGNAME"
 
 echo ""
-echo "ENSURE CHANGELOG.md IS UP-TO-DATE"
+echo "ENSURE 'CHANGELOG.md' IS UP-TO-DATE"
 echo ""
 echo "ENSURE YOU ARE ON THE MAIN BRANCH"
 echo ""
@@ -30,7 +30,10 @@ echo ""
 
 NOTES="See [CHANGELOG.md](https://github.com/rikhuijzer/xrcf/blob/main/CHANGELOG.md) for more information."
 
-read -p "Creating a new tag, which WILL TRIGGER A RELEASE with the following release notes: \"$NOTES\". Are you sure? Type YES to continue. " REPLY
+echo "Ready to create a new tag, which WILL TRIGGER A RELEASE with the following release notes:"
+echo "\"$NOTES\""
+echo ""
+read -p "Are you sure? Type YES to continue. " REPLY
 
 if [[ $REPLY == "YES" ]]; then
     echo ""

--- a/xrcf/script/release.sh
+++ b/xrcf/script/release.sh
@@ -21,6 +21,10 @@ echo "ENSURE CHANGELOG.md IS UP-TO-DATE"
 echo ""
 echo "ENSURE YOU ARE ON THE MAIN BRANCH"
 echo ""
+echo "ENSURE 'cargo publish --dry-run' SUCCEEDED"
+echo ""
+echo "ENSURE 'cargo publish' SUCCEEDED"
+echo ""
 
 NOTES="See [CHANGELOG.md](https://github.com/rikhuijzer/xrcf/blob/main/CHANGELOG.md) for more information."
 

--- a/xrcf/src/convert/mod.rs
+++ b/xrcf/src/convert/mod.rs
@@ -122,7 +122,7 @@ pub fn apply_rewrites(
     root: Arc<RwLock<dyn Op>>,
     rewrites: &[&dyn Rewrite],
 ) -> Result<RewriteResult> {
-    let max_iterations = 16;
+    let max_iterations = 1024;
     let mut root = root;
     let mut has_changed = false;
     for _ in 0..max_iterations {
@@ -142,7 +142,7 @@ pub fn apply_rewrites(
             }
         }
     }
-    tracing::warn!("too many rewrite iterations");
+    tracing::warn!("Too many rewrite iterations");
     Ok(RewriteResult::Changed(ChangedOp::new(root)))
 }
 

--- a/xrcf/src/dialect/scf/op.rs
+++ b/xrcf/src/dialect/scf/op.rs
@@ -27,11 +27,17 @@ pub struct IfOp {
 }
 
 impl IfOp {
+    pub fn els(&self) -> Option<Arc<RwLock<Region>>> {
+        self.els.clone()
+    }
     pub fn then(&self) -> Option<Arc<RwLock<Region>>> {
         self.then.clone()
     }
-    pub fn els(&self) -> Option<Arc<RwLock<Region>>> {
-        self.els.clone()
+    pub fn set_els(&mut self, els: Option<Arc<RwLock<Region>>>) {
+        self.els = els;
+    }
+    pub fn set_then(&mut self, then: Option<Arc<RwLock<Region>>>) {
+        self.then = then;
     }
 }
 

--- a/xrcf/src/dialect/scf/op.rs
+++ b/xrcf/src/dialect/scf/op.rs
@@ -1,5 +1,6 @@
 use crate::ir::Block;
 use crate::ir::GuardedOperation;
+use crate::ir::GuardedRegion;
 use crate::ir::Op;
 use crate::ir::Operation;
 use crate::ir::OperationName;
@@ -57,6 +58,16 @@ impl Op for IfOp {
     }
     fn operation(&self) -> &Arc<RwLock<Operation>> {
         &self.operation
+    }
+    fn ops(&self) -> Vec<Arc<RwLock<dyn Op>>> {
+        let mut ops = vec![];
+        if let Some(then) = self.then.clone() {
+            ops.extend(then.ops());
+        }
+        if let Some(els) = self.els.clone() {
+            ops.extend(els.ops());
+        }
+        ops
     }
     fn display(&self, f: &mut Formatter<'_>, indent: i32) -> std::fmt::Result {
         let has_results = !self.operation.results().is_empty();

--- a/xrcf/src/dialect/scf/op.rs
+++ b/xrcf/src/dialect/scf/op.rs
@@ -61,10 +61,10 @@ impl Op for IfOp {
     }
     fn ops(&self) -> Vec<Arc<RwLock<dyn Op>>> {
         let mut ops = vec![];
-        if let Some(then) = self.then.clone() {
+        if let Some(then) = self.then() {
             ops.extend(then.ops());
         }
-        if let Some(els) = self.els.clone() {
+        if let Some(els) = self.els() {
             ops.extend(els.ops());
         }
         ops

--- a/xrcf/src/dialect/scf/op.rs
+++ b/xrcf/src/dialect/scf/op.rs
@@ -34,6 +34,7 @@ impl IfOp {
         self.els.clone()
     }
 }
+
 impl Op for IfOp {
     fn operation_name() -> OperationName {
         OperationName::new("scf.if".to_string())

--- a/xrcf/src/ir/op.rs
+++ b/xrcf/src/ir/op.rs
@@ -180,6 +180,10 @@ pub trait Op {
         }
     }
     /// Return ops that are children of this op (inside blocks that are inside the region).
+    ///
+    /// Some ops may decide to override this implementation if the children are
+    /// not located inside the main region of the op. For example, the `scf.if`
+    /// operation contains two regions: the "then" region and the "else" region.
     fn ops(&self) -> Vec<Arc<RwLock<dyn Op>>> {
         let region = self.region();
         if let Some(region) = region {

--- a/xrcf/src/transform.rs
+++ b/xrcf/src/transform.rs
@@ -140,9 +140,7 @@ pub fn default_passes() -> Vec<Arg> {
     vec![
         Arg::new("convert-scf-to-cf")
             .long("convert-scf-to-cf")
-            .help(
-                "Convert structured control flow (scf) operations to control flow (cf) operations",
-            )
+            .help("Convert structured control flow (scf) operations to cf")
             .action(ArgAction::SetTrue),
         Arg::new("convert-cf-to-llvm")
             .long("convert-cf-to-llvm")

--- a/xrcf/src/transform.rs
+++ b/xrcf/src/transform.rs
@@ -144,7 +144,7 @@ pub fn default_passes() -> Vec<Arg> {
             .action(ArgAction::SetTrue),
         Arg::new("convert-cf-to-llvm")
             .long("convert-cf-to-llvm")
-            .help("Convert control flow (cf) operations to LLVM IR")
+            .help("Convert control flow (cf) operations to LLVM")
             .action(ArgAction::SetTrue),
         Arg::new("convert-experimental-to-mlir")
             .long("convert-experimental-to-mlir")
@@ -152,7 +152,7 @@ pub fn default_passes() -> Vec<Arg> {
             .action(ArgAction::SetTrue),
         Arg::new("convert-func-to-llvm")
             .long("convert-func-to-llvm")
-            .help("Convert function operations to LLVM IR")
+            .help("Convert function operations to LLVM")
             .action(ArgAction::SetTrue),
         Arg::new("convert-mlir-to-llvmir")
             .long("convert-mlir-to-llvmir")


### PR DESCRIPTION
Allows lowering
```arnoldc
IT'S SHOWTIME

HEY CHRISTMAS TREE x
YOU SET US UP @I LIED

BECAUSE I'M GOING TO SAY PLEASE x
  TALK TO THE HAND "x was true"
BULLSHIT
  TALK TO THE HAND "x was false"
YOU HAVE NO RESPECT FOR LOGIC

YOU HAVE BEEN TERMINATED
```
which returns:
```sh
$ java -jar ArnoldC.jar tmp.arnoldc; java tmp
x was false
```
to
```mlir
func.func @main() -> i32 {
  %false = arith.constant false
  scf.if %false {
    experimental.printf("x was true")
  } else {
    experimental.printf("x was false")
  }
  %0 = arith.constant 0 : i32
  return %0 : i32
}
```