### PR TITLE
Support `scf.if` without `yield`

### DIFF
--- a/xrcf/src/convert/scf_to_cf.rs
+++ b/xrcf/src/convert/scf_to_cf.rs
@@ -39,15 +39,16 @@ fn add_block_from_region(
 ) -> Result<Arc<RwLock<OpOperand>>> {
     let mut ops = region.ops();
     let ops_clone = ops.clone();
-    let yield_op = ops_clone.last().unwrap();
-    let yield_op = yield_op.try_read().unwrap();
-    let yield_op = yield_op
+    let last_op = ops_clone.last().unwrap();
+    let last_op = last_op.try_read().unwrap();
+    let yield_op = last_op
         .as_any()
-        .downcast_ref::<dialect::scf::YieldOp>()
-        .unwrap();
-    let new_op = lower_yield_op(&yield_op, merge_label)?;
-    ops.pop();
-    ops.push(new_op.clone());
+        .downcast_ref::<dialect::scf::YieldOp>();
+    if let Some(yield_op) = yield_op {
+        let new_op = lower_yield_op(&yield_op, merge_label)?;
+        ops.pop();
+        ops.push(new_op.clone());
+    }
 
     let unset_block = parent_region.add_empty_block();
     let block = unset_block.set_parent(Some(parent_region.clone()));

--- a/xrcf/src/dialect/scf/op.rs
+++ b/xrcf/src/dialect/scf/op.rs
@@ -57,9 +57,9 @@ impl Op for IfOp {
             write!(f, "{} = ", self.operation.results())?;
         }
         write!(f, "{} ", self.operation.name())?;
-        write!(f, "{} ", self.operation.operands())?;
+        write!(f, "{}", self.operation.operands())?;
         if has_results {
-            write!(f, "-> ({})", self.operation.results().types())?;
+            write!(f, " -> ({})", self.operation.results().types())?;
         }
         let then = self.then.clone().expect("Expected `then` region");
         let then = then.try_read().unwrap();
@@ -80,9 +80,11 @@ impl Parse for IfOp {
         let mut operation = Operation::default();
         operation.set_parent(parent.clone());
         let results = parser.parse_op_results_into(TOKEN_KIND, &mut operation)?;
-        parser.expect(TokenKind::Equal)?;
+        let has_results = !results.values().is_empty();
+        if has_results {
+            parser.expect(TokenKind::Equal)?;
+        }
         parser.parse_operation_name_into::<IfOp>(&mut operation)?;
-
         let parent = parent.expect("Expected parent");
         let _condition = parser.parse_op_operand_into(
             parent.clone(),
@@ -90,8 +92,8 @@ impl Parse for IfOp {
             &mut operation,
         )?;
 
-        if parser.check(TokenKind::Arrow) {
-            parser.advance();
+        if has_results {
+            parser.expect(TokenKind::Arrow)?;
             parser.expect(TokenKind::LParen)?;
             let return_types = parser.parse_types()?;
             results.set_types(return_types);

--- a/xrcf/src/ir/operation.rs
+++ b/xrcf/src/ir/operation.rs
@@ -332,8 +332,16 @@ impl Operation {
     }
     pub fn successors(&self) -> Vec<Arc<RwLock<dyn Op>>> {
         let parent = self.parent();
-        let parent = parent.expect("no parent");
-        let index = parent.index_of(self).expect("expected index");
+        let parent = parent.expect("Expected parent");
+        let index = match parent.index_of(self) {
+            Some(index) => index,
+            None => {
+                panic!(
+                    "Expected index. Is the parent set correctly for the following op?\n{}",
+                    self
+                );
+            }
+        };
         let ops = parent.ops();
         let ops = ops.try_read().unwrap();
         ops[index + 1..].to_vec()

--- a/xrcf/src/transform.rs
+++ b/xrcf/src/transform.rs
@@ -170,13 +170,6 @@ pub fn transform<T: TransformDispatch>(
         if let RewriteResult::Changed(_) = new_result {
             result = new_result;
         }
-
-        if pass.to_string() != Canonicalize::NAME {
-            let canonicalize_result = Canonicalize::convert(op.clone())?;
-            if let RewriteResult::Changed(_) = canonicalize_result {
-                result = canonicalize_result;
-            }
-        }
     }
 
     Ok(result)

--- a/xrcf/tests/convert/scf_to_cf.rs
+++ b/xrcf/tests/convert/scf_to_cf.rs
@@ -72,14 +72,14 @@ fn test_if_without_yield() {
       %x = arith.constant false
       cf.cond_br %x, ^bb1, ^bb2
     ^bb1: 
-      %c0_i64 = arith.constant 0 : i64
+      %0 = arith.constant 0 : i64
       cf.br ^bb3
     ^bb2:
-      %c1_i64 = arith.constant 1 : i64
+      %1 = arith.constant 1 : i64
       cf.br ^bb3
     ^bb3:
-      %c0_i64_0 = arith.constant 0 : i64
-      return %c0_i64_0 : i64
+      %2 = arith.constant 0 : i64
+      return %2 : i64
     }
     "#};
     let (module, actual) = Tester::parse(src);
@@ -87,5 +87,5 @@ fn test_if_without_yield() {
     Tester::check_lines_contain(&actual, &src, Location::caller());
     let (module, actual) = Tester::transform(flags(), src);
     Tester::verify(module);
-    Tester::check_lines_exact(&actual, expected, Location::caller());
+    Tester::check_lines_contain(&actual, expected, Location::caller());
 }

--- a/xrcf/tests/convert/scf_to_cf.rs
+++ b/xrcf/tests/convert/scf_to_cf.rs
@@ -51,3 +51,41 @@ fn test_if() {
     Tester::verify(module);
     Tester::check_lines_exact(&actual, expected, Location::caller());
 }
+
+#[test]
+fn test_if_without_yield() {
+    Tester::init_tracing();
+    let src = indoc! {r#"
+    func.func @main() -> i64 {
+      %x = arith.constant false
+      scf.if %x {
+        %0 = arith.constant 0 : i64
+      } else {
+        %1 = arith.constant 1 : i64
+      }
+      %2 = arith.constant 0 : i64
+      return %2 : i64
+    }
+    "#};
+    let expected = indoc! {r#"
+    func.func @main() -> i64 {
+      %x = arith.constant false
+      cf.cond_br %x, ^bb1, ^bb2
+    ^bb1: 
+      %c0_i64 = arith.constant 0 : i64
+      cf.br ^bb3
+    ^bb2:
+      %c1_i64 = arith.constant 1 : i64
+      cf.br ^bb3
+    ^bb3:
+      %c0_i64_0 = arith.constant 0 : i64
+      return %c0_i64_0 : i64
+    }
+    "#};
+    let (module, actual) = Tester::parse(src);
+    Tester::verify(module);
+    Tester::check_lines_contain(&actual, &src, Location::caller());
+    let (module, actual) = Tester::transform(flags(), src);
+    Tester::verify(module);
+    Tester::check_lines_exact(&actual, expected, Location::caller());
+}


### PR DESCRIPTION
Allows lowering
```mlir
func.func @main() -> i64 {
  %x = arith.constant 0 : i1
  scf.if %x {
    %0 = arith.constant 0 : i64
  } else {
    %1 = arith.constant 1 : i64
  }
  %2 = arith.constant 0 : i64
  return %2 : i64
}
```
to
```mlir
func.func @main() -> i64 {
  %x = arith.constant false
  cf.cond_br %x, ^bb1, ^bb2
^bb1: 
  %0 = arith.constant 0 : i64
  cf.br ^bb3
^bb2:
  %1 = arith.constant 1 : i64
  cf.br ^bb3
^bb3:
  %2 = arith.constant 0 : i64
  return %2 : i64
}
```
Similar to `mlir-opt --convert-scf-to-cf`.