### PR TITLE
Add `--print-ir-before-all` command line argument

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+xrcf/script/* linguist-vendored

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: release
 
 # The build always runs, but only releases on tag, see the last step.
 on:
@@ -76,7 +76,8 @@ jobs:
         id: release
         shell: bash
 
-      - uses: softprops/action-gh-release@v2
+        # Hardcoded commit hash to mitigate supply chain attacks.
+      - uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         if: startsWith(github.ref, 'refs/tags/')
         with:
           fail_on_unmatched_files: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,4 +1,4 @@
-name: ci
+name: check
 
 on:
   push:

--- a/arnoldc/src/main.rs
+++ b/arnoldc/src/main.rs
@@ -107,7 +107,7 @@ mod tests {
     use xrcf::tester::Tester;
 
     fn run_app(
-        stdout: Option<Arc<RwLock<dyn std::io::Write + Send>>>,
+        out: Option<Arc<RwLock<dyn std::io::Write + Send>>>,
         args: Vec<&str>,
         input_text: &str,
     ) -> Result<RewriteResult> {
@@ -119,8 +119,8 @@ mod tests {
         if args.contains(&"--print-ir-before-all") {
             options.set_print_ir_before_all(true);
         }
-        if let Some(stdout) = stdout {
-            options.set_writer(stdout);
+        if let Some(out) = out {
+            options.set_writer(out);
         }
         let result = parse_and_transform(input_text, &options)?;
         Ok(result)

--- a/arnoldc/src/main.rs
+++ b/arnoldc/src/main.rs
@@ -11,6 +11,7 @@ use std::io::Read;
 use xrcf::convert::RewriteResult;
 use xrcf::init_subscriber;
 use xrcf::Passes;
+use xrcf::TransformOptions;
 
 use crate::transform::parse_and_transform;
 
@@ -74,6 +75,7 @@ fn main() {
         init_tracing(tracing::Level::INFO);
     }
     let passes = passes_from_args(args, matches.clone());
+    let options = TransformOptions::from_args(matches.clone(), passes.clone());
 
     let input = matches.get_one::<String>("input").unwrap();
 
@@ -85,7 +87,7 @@ fn main() {
         std::fs::read_to_string(input).unwrap()
     };
 
-    let result = parse_and_transform(&input_text, &passes).unwrap();
+    let result = parse_and_transform(&input_text, &options).unwrap();
     let result = match result {
         RewriteResult::Changed(op) => op.op.try_read().unwrap().to_string(),
         RewriteResult::Unchanged => input_text.to_string(),
@@ -106,7 +108,8 @@ mod tests {
         let args_owned: Vec<String> = args.iter().map(|&s| s.to_string()).collect();
         let _matches = cli.try_get_matches_from(args_owned)?;
         let passes = Passes::from_convert_vec(args);
-        let result = parse_and_transform(input_text, &passes)?;
+        let options = TransformOptions::from_passes(passes.clone());
+        let result = parse_and_transform(input_text, &options)?;
         Ok(result)
     }
 

--- a/arnoldc/src/main.rs
+++ b/arnoldc/src/main.rs
@@ -183,7 +183,6 @@ mod tests {
         // ----- // IR Dump before convert-func-to-llvm //----- //
         // ----- // IR Dump before convert-mlir-to-llvmir //----- //
         "#};
-        println!("printed:\n{printed}");
         Tester::check_lines_contain(&printed, expected, Location::caller());
     }
 }

--- a/arnoldc/src/main.rs
+++ b/arnoldc/src/main.rs
@@ -33,7 +33,7 @@ struct ArnoldcArgs {
 }
 
 fn cli() -> Command {
-    let cli = Command::new("arnoldc").args(xrcf::default_passes());
+    let cli = Command::new("arnoldc").args(xrcf::default_arguments());
     let cli = ArnoldcArgs::augment_args(cli);
     cli
 }

--- a/arnoldc/src/transform.rs
+++ b/arnoldc/src/transform.rs
@@ -16,7 +16,6 @@ use xrcf::parser::ParserDispatch;
 use xrcf::parser::TokenKind;
 use xrcf::transform;
 use xrcf::DefaultTransformDispatch;
-use xrcf::Passes;
 use xrcf::SinglePass;
 use xrcf::TransformDispatch;
 use xrcf::TransformOptions;
@@ -138,6 +137,7 @@ mod tests {
     use std::panic::Location;
     use tracing;
     use xrcf::tester::Tester;
+    use xrcf::Passes;
 
     fn flags() -> Vec<&'static str> {
         vec!["--convert-arnold-to-mlir"]
@@ -195,6 +195,7 @@ mod tests {
     fn print_heading(msg: &str, src: &str, passes: &Passes) {
         tracing::info!("{msg} ({passes}):\n```\n{src}\n```\n");
     }
+
     fn test_transform(src: &str, passes: Vec<&str>) -> (Arc<RwLock<dyn Op>>, String) {
         Tester::init_tracing();
         let src = src.trim();

--- a/arnoldc/src/transform.rs
+++ b/arnoldc/src/transform.rs
@@ -19,7 +19,7 @@ use xrcf::DefaultTransformDispatch;
 use xrcf::Passes;
 use xrcf::SinglePass;
 use xrcf::TransformDispatch;
-
+use xrcf::TransformOptions;
 pub struct ArnoldParserDispatch;
 
 fn is_function_call<T: ParserDispatch>(parser: &Parser<T>) -> bool {
@@ -123,10 +123,10 @@ fn preprocess(src: &str) -> String {
     result
 }
 
-pub fn parse_and_transform(src: &str, passes: &Passes) -> Result<RewriteResult> {
+pub fn parse_and_transform(src: &str, options: &TransformOptions) -> Result<RewriteResult> {
     let src = preprocess(src);
     let op = Parser::<ArnoldParserDispatch>::parse(&src)?;
-    let result = transform::<ArnoldTransformDispatch>(op, passes)?;
+    let result = transform::<ArnoldTransformDispatch>(op, options)?;
     Ok(result)
 }
 
@@ -200,7 +200,8 @@ mod tests {
         let src = src.trim();
         let passes = Passes::from_vec(passes);
         print_heading("Before", src, &passes);
-        let result = parse_and_transform(src, &passes).unwrap();
+        let options = TransformOptions::from_passes(passes.clone());
+        let result = parse_and_transform(src, &options).unwrap();
         let new_root_op = match result {
             RewriteResult::Changed(changed_op) => changed_op.op,
             RewriteResult::Unchanged => {

--- a/xrcf-bin/src/main.rs
+++ b/xrcf-bin/src/main.rs
@@ -23,7 +23,7 @@ struct XRCFArgs {
 }
 
 fn cli() -> Command {
-    let cli = Command::new("xrcf").args(xrcf::default_passes());
+    let cli = Command::new("xrcf").args(xrcf::default_arguments());
     let cli = XRCFArgs::augment_args(cli);
     cli
 }

--- a/xrcf/script/release.sh
+++ b/xrcf/script/release.sh
@@ -4,7 +4,7 @@
 # Trigger a release
 #
 
-set -e
+set -e -u -o pipefail
 
 # We have to run this locally because tags created from workflows do not
 # trigger new workflows.

--- a/xrcf/script/release.sh
+++ b/xrcf/script/release.sh
@@ -28,7 +28,11 @@ echo ""
 echo "ENSURE 'cargo publish' SUCCEEDED"
 echo ""
 
-NOTES="See [CHANGELOG.md](https://github.com/rikhuijzer/xrcf/blob/main/CHANGELOG.md) for more information."
+NOTES="\`xrcf-bin\` is a compiler that can compile basic MLIR programs to LLVM IR, and can be used for testing the xrcf package. This binary contains all the default passes such as \`--convert-func-to-llvm\`.
+
+\`arnoldc\` is a compiler that can compile basic ArnoldC programs to LLVM IR. Next to the default passes, this binary contains the pass \`--convert-arnold-to-mlir\` which can lower ArnoldC programs to MLIR. From there, the default passes such as \`--convert-func-to-llvm\` can be used to lower ArnoldC to LLVM IR.
+
+See [CHANGELOG.md](https://github.com/rikhuijzer/xrcf/blob/main/CHANGELOG.md) for more information about changes since the last release."
 
 echo "Ready to create a new tag, which WILL TRIGGER A RELEASE with the following release notes:"
 echo "\"$NOTES\""

--- a/xrcf/src/lib.rs
+++ b/xrcf/src/lib.rs
@@ -55,6 +55,7 @@ pub use transform::DefaultTransformDispatch;
 pub use transform::Passes;
 pub use transform::SinglePass;
 pub use transform::TransformDispatch;
+pub use transform::TransformOptions;
 
 /// Dialects can define new operations, attributes, and types.
 /// Each dialect is given an unique namespace that is prefixed.

--- a/xrcf/src/lib.rs
+++ b/xrcf/src/lib.rs
@@ -48,7 +48,7 @@ pub mod targ3t;
 pub mod tester;
 mod transform;
 
-pub use transform::default_passes;
+pub use transform::default_arguments;
 pub use transform::init_subscriber;
 pub use transform::transform;
 pub use transform::DefaultTransformDispatch;

--- a/xrcf/src/tester.rs
+++ b/xrcf/src/tester.rs
@@ -9,6 +9,7 @@ use crate::parser::Parser;
 use crate::transform;
 use crate::DefaultTransformDispatch;
 use crate::Passes;
+use crate::TransformOptions;
 use std::cmp::max;
 use std::panic::Location;
 use std::sync::Arc;
@@ -122,7 +123,8 @@ impl Tester {
             }
         }
         let passes = Passes::from_convert_vec(arguments.clone());
-        let result = transform::<DefaultTransformDispatch>(module.clone(), &passes).unwrap();
+        let options = TransformOptions::from_passes(passes);
+        let result = transform::<DefaultTransformDispatch>(module.clone(), &options).unwrap();
         let new_root_op = match result {
             RewriteResult::Changed(changed_op) => changed_op.op,
             RewriteResult::Unchanged => {

--- a/xrcf/src/transform.rs
+++ b/xrcf/src/transform.rs
@@ -133,10 +133,14 @@ impl TransformDispatch for DefaultTransformDispatch {
     }
 }
 
-/// Collection of passes that are available in xrcf.
+/// Default arguments that are available in xrcf.
+///
+/// This includes options such as `--print-ir-before-all`, but also the default
+/// passes such as `--convert-func-to-llvm`. `--debug` is not included to allow
+/// downstream projects to handle the logging differently.
 ///
 /// For an example on how to use this, see the usage in the `arnoldc/` directory.
-pub fn default_passes() -> Vec<Arg> {
+pub fn default_arguments() -> Vec<Arg> {
     vec![
         Arg::new("convert-scf-to-cf")
             .long("convert-scf-to-cf")
@@ -157,6 +161,10 @@ pub fn default_passes() -> Vec<Arg> {
         Arg::new("convert-mlir-to-llvmir")
             .long("convert-mlir-to-llvmir")
             .help("Convert MLIR to LLVM IR")
+            .action(ArgAction::SetTrue),
+        Arg::new("print-ir-before-all")
+            .long("print-ir-before-all")
+            .help("Print the IR before each pass")
             .action(ArgAction::SetTrue),
     ]
 }

--- a/xrcf/src/transform.rs
+++ b/xrcf/src/transform.rs
@@ -132,6 +132,9 @@ impl TransformOptions {
     pub fn passes(&self) -> &Passes {
         &self.passes
     }
+    pub fn set_print_ir_before_all(&mut self, print_ir_before_all: bool) {
+        self.print_ir_before_all = print_ir_before_all;
+    }
     pub fn set_writer(&mut self, writer: Arc<RwLock<dyn std::io::Write + Send>>) {
         self.writer = writer;
     }
@@ -222,6 +225,7 @@ pub fn transform<T: TransformDispatch>(
 ) -> Result<RewriteResult> {
     let mut result = RewriteResult::Unchanged;
     for pass in options.passes().vec() {
+        println!("print_ir_before_all: {}", options.print_ir_before_all());
         if options.print_ir_before_all() {
             writeln!(
                 &mut *options.writer.write().unwrap(),

--- a/xrcf/src/transform.rs
+++ b/xrcf/src/transform.rs
@@ -116,14 +116,14 @@ impl TransformOptions {
         TransformOptions {
             passes,
             print_ir_before_all,
-            writer: Arc::new(RwLock::new(std::io::stdout())),
+            writer: Arc::new(RwLock::new(std::io::stderr())),
         }
     }
     pub fn from_passes(passes: Passes) -> TransformOptions {
         TransformOptions {
             passes,
             print_ir_before_all: false,
-            writer: Arc::new(RwLock::new(std::io::stdout())),
+            writer: Arc::new(RwLock::new(std::io::stderr())),
         }
     }
     pub fn print_ir_before_all(&self) -> bool {

--- a/xrcf/src/transform.rs
+++ b/xrcf/src/transform.rs
@@ -225,11 +225,10 @@ pub fn transform<T: TransformDispatch>(
 ) -> Result<RewriteResult> {
     let mut result = RewriteResult::Unchanged;
     for pass in options.passes().vec() {
-        println!("print_ir_before_all: {}", options.print_ir_before_all());
         if options.print_ir_before_all() {
             writeln!(
                 &mut *options.writer.write().unwrap(),
-                "// ----- // IR Dump before {pass} //----- //\n{}",
+                "// ----- // IR Dump before {pass} //----- //\n{}\n\n",
                 op.try_read().unwrap()
             )?;
         }

--- a/xrcf/src/transform.rs
+++ b/xrcf/src/transform.rs
@@ -105,7 +105,9 @@ pub struct TransformOptions {
     /// Print the IR before each pass.
     ///
     /// `print-ir-after-all` is not implemented because I don't see when it
-    /// would be useful.
+    /// would be useful. `print-ir-before-all` is useful to see the IR after
+    /// parsing, but seeing the IR after the last pass is already the final
+    /// output.
     print_ir_before_all: bool,
     writer: Arc<RwLock<dyn std::io::Write + Send>>,
 }


### PR DESCRIPTION
Adds `--print-ir-before-all` to the default command line arguments.

The following example gives the same output in `arnoldc` and `xrcf-bin`:

`tmp.mlir`:
```mlir
func.func @main() -> i32 {
    %0 = arith.constant 1 : i32
    return %0 : i32
}
```
with
```sh
$ xrcf-bin \
    --convert-func-to-llvm \
    --convert-mlir-to-llvmir \
    tmp.mlir \
    --print-ir-before-all
```
prints
```
// ----- // IR Dump before convert-func-to-llvm //----- //
module {
  func.func @main() -> i32 {
    %0 = arith.constant 1 : i32
    return %0 : i32
  }
}


// ----- // IR Dump before convert-mlir-to-llvmir //----- //
module {
  llvm.func @main() -> i32 {
    %0 = llvm.mlir.constant(1 : i32) : i32
    llvm.return %0 : i32
  }
}


; ModuleID = 'LLVMDialectModule'
source_filename = "LLVMDialectModule"

define i32 @main() {
  ret i32 1
}

!llvm.module.flags = !{!0}

!0 = !{i32 2, !"Debug Info Version", i32 3}
```
where the dumps are sent to stderr similar to `mlir-opt`.