### PR TITLE
Introduce `Shared` and `SharedExt`, and refactor

### DIFF
--- a/arnoldc/src/arnold.rs
+++ b/arnoldc/src/arnold.rs
@@ -155,9 +155,8 @@ impl Op for BeginMainOp {
         let operation = self.operation.re();
         write!(f, "{} ", operation.name())?;
         let region = operation.region().unwrap();
-        let region = region.re();
         write!(f, "()")?;
-        region.display(f, indent)?;
+        region.re().display(f, indent)?;
         Ok(())
     }
 }

--- a/arnoldc/src/arnold.rs
+++ b/arnoldc/src/arnold.rs
@@ -17,7 +17,7 @@ use xrcf::parser::Parse;
 use xrcf::parser::Parser;
 use xrcf::parser::ParserDispatch;
 use xrcf::parser::TokenKind;
-use xrcf::shared::RwLockExt;
+use xrcf::shared::SharedExt;
 
 /// The token kind used for variables in ArnoldC.
 ///

--- a/arnoldc/src/arnold.rs
+++ b/arnoldc/src/arnold.rs
@@ -172,11 +172,11 @@ impl Parse for BeginMainOp {
         let name = BeginMainOp::operation_name();
         parser.parse_arnold_operation_name_into(name, &mut operation)?;
 
-        let operation = Arc::new(RwLock::new(operation));
+        let operation = Shared::new(operation.into());
         let op = BeginMainOp {
             operation: operation.clone(),
         };
-        let op = Arc::new(RwLock::new(op));
+        let op = Shared::new(op.into());
         let region = parser.parse_region(op.clone())?;
         let mut operation = operation.wr();
         operation.set_region(Some(region.clone()));
@@ -227,12 +227,12 @@ impl Parse for CallOp {
         let identifier = identifier.lexeme.clone();
         parser.expect(TokenKind::LParen)?;
         parser.expect(TokenKind::RParen)?;
-        let operation = Arc::new(RwLock::new(operation));
+        let operation = Shared::new(operation.into());
         let op = CallOp {
             operation: operation.clone(),
             identifier: Some(identifier),
         };
-        Ok(Arc::new(RwLock::new(op)))
+        Ok(Shared::new(op.into()))
     }
 }
 
@@ -270,12 +270,12 @@ impl Parse for DeclareIntOp {
         let name = DeclareIntOp::operation_name();
         parser.parse_arnold_operation_name_into(name, &mut operation)?;
         let result = parser.parse_op_result_into(TOKEN_KIND, &mut operation)?;
-        let operation = Arc::new(RwLock::new(operation));
+        let operation = Shared::new(operation.into());
         let op = DeclareIntOp { operation };
-        let op = Arc::new(RwLock::new(op));
+        let op = Shared::new(op.into());
         result.set_defining_op(Some(op.clone()));
         let typ = IntegerType::new(16);
-        let typ = Arc::new(RwLock::new(typ));
+        let typ = Shared::new(typ.into());
         result.set_typ(typ);
         Ok(op)
     }
@@ -335,13 +335,13 @@ impl Parse for IfOp {
         let name = IfOp::operation_name();
         parser.parse_arnold_operation_name_into(name, &mut operation)?;
         parser.parse_op_operand_into(parent.clone().unwrap(), TOKEN_KIND, &mut operation)?;
-        let operation = Arc::new(RwLock::new(operation));
+        let operation = Shared::new(operation.into());
         let op = IfOp {
             operation: operation.clone(),
             then: None,
             els: None,
         };
-        let op = Arc::new(RwLock::new(op));
+        let op = Shared::new(op.into());
         let then = parser.parse_region(op.clone())?;
         let else_keyword = parser.expect(TokenKind::BareIdentifier)?;
         if else_keyword.lexeme != "BULLSHIT" {
@@ -409,13 +409,13 @@ impl Parse for PrintOp {
         operation.set_parent(parent.clone());
         let name = PrintOp::operation_name();
         parser.parse_arnold_operation_name_into(name, &mut operation)?;
-        let operation = Arc::new(RwLock::new(operation));
+        let operation = Shared::new(operation.into());
         let text = parser.parse_op_operand(parent.clone().unwrap(), TOKEN_KIND)?;
         let mut op = PrintOp {
             operation: operation.clone(),
         };
         op.set_text(text);
-        Ok(Arc::new(RwLock::new(op)))
+        Ok(Shared::new(op.into()))
     }
 }
 
@@ -459,10 +459,10 @@ impl Parse for SetInitialValueOp {
             parser.parse_arnold_constant_into(&mut operation)?;
         }
 
-        let operation = Arc::new(RwLock::new(operation));
+        let operation = Shared::new(operation.into());
         let op = SetInitialValueOp {
             operation: operation.clone(),
         };
-        Ok(Arc::new(RwLock::new(op)))
+        Ok(Shared::new(op.into()))
     }
 }

--- a/arnoldc/src/arnold.rs
+++ b/arnoldc/src/arnold.rs
@@ -255,7 +255,7 @@ impl Op for DeclareIntOp {
     }
     fn display(&self, f: &mut Formatter<'_>, _indent: i32) -> std::fmt::Result {
         write!(f, "{}", Self::operation_name())?;
-        write!(f, " {}", self.operation().read().unwrap().results())?;
+        write!(f, " {}", self.operation().re().results())?;
         Ok(())
     }
 }

--- a/arnoldc/src/arnold.rs
+++ b/arnoldc/src/arnold.rs
@@ -17,6 +17,7 @@ use xrcf::parser::Parse;
 use xrcf::parser::Parser;
 use xrcf::parser::ParserDispatch;
 use xrcf::parser::TokenKind;
+use xrcf::shared::RwLockExt;
 
 /// The token kind used for variables in ArnoldC.
 ///
@@ -348,7 +349,7 @@ impl Parse for IfOp {
         }
         let els = parser.parse_region(op.clone())?;
         let op_write = op.clone();
-        let mut op_write = op_write.try_write().unwrap();
+        let mut op_write = op_write.wr();
         op_write.then = Some(then);
         op_write.els = Some(els);
         Ok(op)

--- a/arnoldc/src/arnold.rs
+++ b/arnoldc/src/arnold.rs
@@ -151,10 +151,10 @@ impl Op for BeginMainOp {
         &self.operation
     }
     fn display(&self, f: &mut Formatter<'_>, indent: i32) -> std::fmt::Result {
-        let operation = self.operation.try_read().unwrap();
+        let operation = self.operation.re();
         write!(f, "{} ", operation.name())?;
         let region = operation.region().unwrap();
-        let region = region.try_read().unwrap();
+        let region = region.re();
         write!(f, "()")?;
         region.display(f, indent)?;
         Ok(())
@@ -395,7 +395,7 @@ impl Op for PrintOp {
     }
     fn display(&self, f: &mut Formatter<'_>, _indent: i32) -> std::fmt::Result {
         write!(f, "{}", Self::operation_name())?;
-        write!(f, " {}", self.text().try_read().unwrap())?;
+        write!(f, " {}", self.text().re())?;
         Ok(())
     }
 }

--- a/arnoldc/src/arnold.rs
+++ b/arnoldc/src/arnold.rs
@@ -178,7 +178,7 @@ impl Parse for BeginMainOp {
         };
         let op = Arc::new(RwLock::new(op));
         let region = parser.parse_region(op.clone())?;
-        let mut operation = operation.write().unwrap();
+        let mut operation = operation.wr();
         operation.set_region(Some(region.clone()));
         Ok(op)
     }

--- a/arnoldc/src/arnold.rs
+++ b/arnoldc/src/arnold.rs
@@ -17,6 +17,7 @@ use xrcf::parser::Parse;
 use xrcf::parser::Parser;
 use xrcf::parser::ParserDispatch;
 use xrcf::parser::TokenKind;
+use xrcf::shared::Shared;
 use xrcf::shared::SharedExt;
 
 /// The token kind used for variables in ArnoldC.

--- a/arnoldc/src/arnold.rs
+++ b/arnoldc/src/arnold.rs
@@ -152,11 +152,11 @@ impl Op for BeginMainOp {
         &self.operation
     }
     fn display(&self, f: &mut Formatter<'_>, indent: i32) -> std::fmt::Result {
-        let operation = self.operation.re();
+        let operation = self.operation.rd();
         write!(f, "{} ", operation.name())?;
         let region = operation.region().unwrap();
         write!(f, "()")?;
-        region.re().display(f, indent)?;
+        region.rd().display(f, indent)?;
         Ok(())
     }
 }
@@ -255,7 +255,7 @@ impl Op for DeclareIntOp {
     }
     fn display(&self, f: &mut Formatter<'_>, _indent: i32) -> std::fmt::Result {
         write!(f, "{}", Self::operation_name())?;
-        write!(f, " {}", self.operation().re().results())?;
+        write!(f, " {}", self.operation().rd().results())?;
         Ok(())
     }
 }
@@ -395,7 +395,7 @@ impl Op for PrintOp {
     }
     fn display(&self, f: &mut Formatter<'_>, _indent: i32) -> std::fmt::Result {
         write!(f, "{}", Self::operation_name())?;
-        write!(f, " {}", self.text().re())?;
+        write!(f, " {}", self.text().rd())?;
         Ok(())
     }
 }

--- a/arnoldc/src/arnold_to_mlir.rs
+++ b/arnoldc/src/arnold_to_mlir.rs
@@ -48,7 +48,7 @@ impl Rewrite for CallLowering {
         let mut new_op = func::CallOp::from_operation_arc(operation.clone());
         let identifier = format!("@{}", identifier);
         new_op.set_identifier(identifier);
-        let new_op = Arc::new(RwLock::new(new_op));
+        let new_op = Shared::new(new_op));
         op.replace(new_op.clone());
         Ok(RewriteResult::Changed(ChangedOp::new(new_op)))
     }
@@ -92,7 +92,7 @@ impl Rewrite for DeclareIntLowering {
         new_op.set_parent(op.operation().parent().clone().unwrap());
         new_op.set_value(set_initial_value.value());
         set_initial_value.remove();
-        let new_op = Arc::new(RwLock::new(new_op));
+        let new_op = Shared::new(new_op));
         op.replace(new_op.clone());
         Ok(RewriteResult::Changed(ChangedOp::new(new_op)))
     }
@@ -114,7 +114,7 @@ impl Rewrite for FuncLowering {
         let operation = op.operation();
         let mut new_op = func::FuncOp::from_operation_arc(operation.clone());
         new_op.set_identifier(identifier.to_string());
-        let new_op = Arc::new(RwLock::new(new_op));
+        let new_op = Shared::new(new_op));
         op.replace(new_op.clone());
         Ok(RewriteResult::Changed(ChangedOp::new(new_op)))
     }
@@ -155,7 +155,7 @@ impl Rewrite for IfLowering {
         new_op.set_parent(operation.parent().clone().unwrap());
         new_op.set_then(op.then().clone());
         new_op.set_els(op.els().clone());
-        let new_op = Arc::new(RwLock::new(new_op));
+        let new_op = Shared::new(new_op));
         op.replace(new_op.clone());
         Ok(RewriteResult::Changed(ChangedOp::new(new_op)))
     }
@@ -172,11 +172,11 @@ impl ModuleLowering {
         let value = APInt::new(32, 0, true);
         let integer = IntegerAttr::new(typ, value);
         let name = parent.re().unique_value_name("%");
-        let result_type = Arc::new(RwLock::new(typ));
+        let result_type = Shared::new(typ));
         let result = constant.add_new_op_result(&name, result_type.clone());
         let constant = arith::ConstantOp::from_operation(constant);
         constant.set_value(Arc::new(integer));
-        let constant = Arc::new(RwLock::new(constant));
+        let constant = Shared::new(constant));
         result.set_defining_op(Some(constant.clone()));
         constant
     }
@@ -185,24 +185,24 @@ impl ModuleLowering {
         constant: Arc<RwLock<dyn Op>>,
     ) -> Arc<RwLock<dyn Op>> {
         let typ = IntegerType::new(32);
-        let result_type = Arc::new(RwLock::new(typ));
+        let result_type = Shared::new(typ));
         let mut ret = Operation::default();
         ret.set_parent(Some(parent.clone()));
         ret.set_name(func::ReturnOp::operation_name());
         ret.set_anonymous_result(result_type).unwrap();
         let value = constant.result(0);
         let operand = OpOperand::new(value);
-        let operand = Arc::new(RwLock::new(operand));
+        let operand = Shared::new(operand));
         ret.set_operand(0, operand);
         let ret = func::ReturnOp::from_operation(ret);
-        let ret = Arc::new(RwLock::new(ret));
+        let ret = Shared::new(ret));
         ret
     }
     fn return_zero(func: Arc<RwLock<dyn Op>>) {
         let operation = func.operation();
         let typ = IntegerType::new(32);
         operation
-            .set_anonymous_result(Arc::new(RwLock::new(typ)))
+            .set_anonymous_result(Shared::new(typ)))
             .unwrap();
 
         let ops = func.ops();
@@ -263,7 +263,7 @@ impl Rewrite for PrintLowering {
         let op = op.as_any().downcast_ref::<arnold::PrintOp>().unwrap();
         let mut operation = Operation::default();
         operation.set_name(experimental::PrintfOp::operation_name());
-        let operation = Arc::new(RwLock::new(operation));
+        let operation = Shared::new(operation));
         let mut new_op = experimental::PrintfOp::from_operation_arc(operation.clone());
         new_op.set_parent(op.operation().parent().clone().unwrap());
 
@@ -285,7 +285,7 @@ impl Rewrite for PrintLowering {
             _ => panic!("expected constant or op result"),
         };
 
-        let new_op = Arc::new(RwLock::new(new_op));
+        let new_op = Shared::new(new_op));
         op.replace(new_op.clone());
         Ok(RewriteResult::Changed(ChangedOp::new(new_op)))
     }

--- a/arnoldc/src/arnold_to_mlir.rs
+++ b/arnoldc/src/arnold_to_mlir.rs
@@ -42,7 +42,7 @@ impl Rewrite for CallLowering {
         Ok(op.as_any().is::<arnold::CallOp>())
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
-        let op = op.re();
+        let op = op.rd();
         let op = op.as_any().downcast_ref::<arnold::CallOp>().unwrap();
         let identifier = op.identifier().unwrap();
         let operation = op.operation();
@@ -76,13 +76,13 @@ impl Rewrite for DeclareIntLowering {
         Ok(op.as_any().is::<arnold::DeclareIntOp>())
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
-        let op = op.re();
+        let op = op.rd();
         let op = op.as_any().downcast_ref::<arnold::DeclareIntOp>().unwrap();
         op.operation().rename_variables(&RENAMER)?;
 
         let successors = op.operation().successors();
         let set_initial_value = successors.first().unwrap();
-        let set_initial_value = set_initial_value.re();
+        let set_initial_value = set_initial_value.rd();
         let set_initial_value = set_initial_value
             .as_any()
             .downcast_ref::<arnold::SetInitialValueOp>()
@@ -109,7 +109,7 @@ impl Rewrite for FuncLowering {
         Ok(op.as_any().is::<arnold::BeginMainOp>())
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
-        let op = op.re();
+        let op = op.rd();
         let op = op.as_any().downcast_ref::<arnold::BeginMainOp>().unwrap();
         let identifier = "@main";
         let operation = op.operation();
@@ -149,7 +149,7 @@ impl Rewrite for IfLowering {
         Ok(op.as_any().is::<arnold::IfOp>())
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
-        let op = op.re();
+        let op = op.rd();
         let op = op.as_any().downcast_ref::<arnold::IfOp>().unwrap();
         let operation = op.operation();
         let mut new_op = scf::IfOp::from_operation_arc(operation.clone());
@@ -172,7 +172,7 @@ impl ModuleLowering {
         let typ = IntegerType::new(32);
         let value = APInt::new(32, 0, true);
         let integer = IntegerAttr::new(typ, value);
-        let name = parent.re().unique_value_name("%");
+        let name = parent.rd().unique_value_name("%");
         let result_type = Shared::new(typ.into());
         let result = constant.add_new_op_result(&name, result_type.clone());
         let constant = arith::ConstantOp::from_operation(constant);
@@ -221,10 +221,10 @@ impl ModuleLowering {
         constant.insert_after(ret.clone());
     }
     fn returns_something(func: Arc<RwLock<dyn Op>>) -> bool {
-        let func = func.re();
+        let func = func.rd();
         let func_op = func.as_any().downcast_ref::<func::FuncOp>().unwrap();
         let result = func_op.operation().results();
-        result.vec().re().len() == 1
+        result.vec().rd().len() == 1
     }
     fn ensure_main_returns_zero(module: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
         let ops = module.ops();
@@ -260,7 +260,7 @@ impl Rewrite for PrintLowering {
         Ok(op.as_any().is::<arnold::PrintOp>())
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
-        let op = op.re();
+        let op = op.rd();
         let op = op.as_any().downcast_ref::<arnold::PrintOp>().unwrap();
         let mut operation = Operation::default();
         operation.set_name(experimental::PrintfOp::operation_name());
@@ -270,7 +270,7 @@ impl Rewrite for PrintLowering {
 
         let operand = op.text();
         let value = operand.value();
-        match &*value.re() {
+        match &*value.rd() {
             // printf("some text")
             Value::Constant(constant) => {
                 let text = constant.value();

--- a/arnoldc/src/arnold_to_mlir.rs
+++ b/arnoldc/src/arnold_to_mlir.rs
@@ -27,6 +27,7 @@ use xrcf::ir::Operation;
 use xrcf::ir::RenameBareToPercent;
 use xrcf::ir::StringAttr;
 use xrcf::ir::Value;
+use xrcf::shared::Shared;
 use xrcf::shared::SharedExt;
 
 const RENAMER: RenameBareToPercent = RenameBareToPercent;
@@ -48,7 +49,7 @@ impl Rewrite for CallLowering {
         let mut new_op = func::CallOp::from_operation_arc(operation.clone());
         let identifier = format!("@{}", identifier);
         new_op.set_identifier(identifier);
-        let new_op = Shared::new(new_op));
+        let new_op = Shared::new(new_op.into());
         op.replace(new_op.clone());
         Ok(RewriteResult::Changed(ChangedOp::new(new_op)))
     }
@@ -92,7 +93,7 @@ impl Rewrite for DeclareIntLowering {
         new_op.set_parent(op.operation().parent().clone().unwrap());
         new_op.set_value(set_initial_value.value());
         set_initial_value.remove();
-        let new_op = Shared::new(new_op));
+        let new_op = Shared::new(new_op.into());
         op.replace(new_op.clone());
         Ok(RewriteResult::Changed(ChangedOp::new(new_op)))
     }
@@ -114,7 +115,7 @@ impl Rewrite for FuncLowering {
         let operation = op.operation();
         let mut new_op = func::FuncOp::from_operation_arc(operation.clone());
         new_op.set_identifier(identifier.to_string());
-        let new_op = Shared::new(new_op));
+        let new_op = Shared::new(new_op.into());
         op.replace(new_op.clone());
         Ok(RewriteResult::Changed(ChangedOp::new(new_op)))
     }
@@ -155,7 +156,7 @@ impl Rewrite for IfLowering {
         new_op.set_parent(operation.parent().clone().unwrap());
         new_op.set_then(op.then().clone());
         new_op.set_els(op.els().clone());
-        let new_op = Shared::new(new_op));
+        let new_op = Shared::new(new_op.into());
         op.replace(new_op.clone());
         Ok(RewriteResult::Changed(ChangedOp::new(new_op)))
     }
@@ -172,11 +173,11 @@ impl ModuleLowering {
         let value = APInt::new(32, 0, true);
         let integer = IntegerAttr::new(typ, value);
         let name = parent.re().unique_value_name("%");
-        let result_type = Shared::new(typ));
+        let result_type = Shared::new(typ.into());
         let result = constant.add_new_op_result(&name, result_type.clone());
         let constant = arith::ConstantOp::from_operation(constant);
         constant.set_value(Arc::new(integer));
-        let constant = Shared::new(constant));
+        let constant = Shared::new(constant.into());
         result.set_defining_op(Some(constant.clone()));
         constant
     }
@@ -185,24 +186,24 @@ impl ModuleLowering {
         constant: Arc<RwLock<dyn Op>>,
     ) -> Arc<RwLock<dyn Op>> {
         let typ = IntegerType::new(32);
-        let result_type = Shared::new(typ));
+        let result_type = Shared::new(typ.into());
         let mut ret = Operation::default();
         ret.set_parent(Some(parent.clone()));
         ret.set_name(func::ReturnOp::operation_name());
         ret.set_anonymous_result(result_type).unwrap();
         let value = constant.result(0);
         let operand = OpOperand::new(value);
-        let operand = Shared::new(operand));
+        let operand = Shared::new(operand.into());
         ret.set_operand(0, operand);
         let ret = func::ReturnOp::from_operation(ret);
-        let ret = Shared::new(ret));
+        let ret = Shared::new(ret.into());
         ret
     }
     fn return_zero(func: Arc<RwLock<dyn Op>>) {
         let operation = func.operation();
         let typ = IntegerType::new(32);
         operation
-            .set_anonymous_result(Shared::new(typ)))
+            .set_anonymous_result(Shared::new(typ.into()))
             .unwrap();
 
         let ops = func.ops();
@@ -263,7 +264,7 @@ impl Rewrite for PrintLowering {
         let op = op.as_any().downcast_ref::<arnold::PrintOp>().unwrap();
         let mut operation = Operation::default();
         operation.set_name(experimental::PrintfOp::operation_name());
-        let operation = Shared::new(operation));
+        let operation = Shared::new(operation.into());
         let mut new_op = experimental::PrintfOp::from_operation_arc(operation.clone());
         new_op.set_parent(op.operation().parent().clone().unwrap());
 
@@ -285,7 +286,7 @@ impl Rewrite for PrintLowering {
             _ => panic!("expected constant or op result"),
         };
 
-        let new_op = Shared::new(new_op));
+        let new_op = Shared::new(new_op.into());
         op.replace(new_op.clone());
         Ok(RewriteResult::Changed(ChangedOp::new(new_op)))
     }

--- a/arnoldc/src/main.rs
+++ b/arnoldc/src/main.rs
@@ -165,7 +165,7 @@ mod tests {
             "--print-ir-before-all",
         ];
         tracing::info!("\nBefore {args:?}:\n{src}");
-        let out: Arc<RwLock<Vec<u8>>> = Arc::new(RwLock::new(Vec::new()));
+        let out: Arc<RwLock<Vec<u8>>> = Shared::new(Vec::new()));
         let result = run_app(Some(out.clone()), args.clone(), &src);
         assert!(result.is_ok());
         let actual = match result.unwrap() {

--- a/arnoldc/src/main.rs
+++ b/arnoldc/src/main.rs
@@ -90,7 +90,7 @@ fn main() {
 
     let result = parse_and_transform(&input_text, &options).unwrap();
     let result = match result {
-        RewriteResult::Changed(op) => op.op.re().to_string(),
+        RewriteResult::Changed(op) => op.op.rd().to_string(),
         RewriteResult::Unchanged => input_text.to_string(),
     };
     println!("{result}");
@@ -171,7 +171,7 @@ mod tests {
         assert!(result.is_ok());
         let actual = match result.unwrap() {
             RewriteResult::Changed(op) => {
-                let op = op.op.re();
+                let op = op.op.rd();
                 op.to_string()
             }
             RewriteResult::Unchanged => panic!("Expected a change"),
@@ -179,7 +179,7 @@ mod tests {
         tracing::info!("\nAfter {args:?}:\n{actual}");
         assert!(actual.contains("define i32 @main"));
 
-        let printed = out.re();
+        let printed = out.rd();
         let printed = String::from_utf8(printed.clone()).unwrap();
         let expected = indoc! {r#"
         // ----- // IR Dump before convert-func-to-llvm //----- //

--- a/arnoldc/src/main.rs
+++ b/arnoldc/src/main.rs
@@ -105,6 +105,7 @@ mod tests {
     use std::sync::Arc;
     use std::sync::RwLock;
     use xrcf::convert::RewriteResult;
+    use xrcf::shared::Shared;
     use xrcf::tester::Tester;
 
     fn run_app(
@@ -165,7 +166,7 @@ mod tests {
             "--print-ir-before-all",
         ];
         tracing::info!("\nBefore {args:?}:\n{src}");
-        let out: Arc<RwLock<Vec<u8>>> = Shared::new(Vec::new()));
+        let out: Arc<RwLock<Vec<u8>>> = Shared::new(Vec::new().into());
         let result = run_app(Some(out.clone()), args.clone(), &src);
         assert!(result.is_ok());
         let actual = match result.unwrap() {

--- a/arnoldc/src/main.rs
+++ b/arnoldc/src/main.rs
@@ -10,6 +10,7 @@ use std::env::ArgsOs;
 use std::io::Read;
 use xrcf::convert::RewriteResult;
 use xrcf::init_subscriber;
+use xrcf::shared::SharedExt;
 use xrcf::Passes;
 use xrcf::TransformOptions;
 
@@ -89,7 +90,7 @@ fn main() {
 
     let result = parse_and_transform(&input_text, &options).unwrap();
     let result = match result {
-        RewriteResult::Changed(op) => op.op.try_read().unwrap().to_string(),
+        RewriteResult::Changed(op) => op.op.re().to_string(),
         RewriteResult::Unchanged => input_text.to_string(),
     };
     println!("{result}");
@@ -169,7 +170,7 @@ mod tests {
         assert!(result.is_ok());
         let actual = match result.unwrap() {
             RewriteResult::Changed(op) => {
-                let op = op.op.try_read().unwrap();
+                let op = op.op.re();
                 op.to_string()
             }
             RewriteResult::Unchanged => panic!("Expected a change"),
@@ -177,7 +178,7 @@ mod tests {
         tracing::info!("\nAfter {args:?}:\n{actual}");
         assert!(actual.contains("define i32 @main"));
 
-        let printed = out.try_read().unwrap();
+        let printed = out.re();
         let printed = String::from_utf8(printed.clone()).unwrap();
         let expected = indoc! {r#"
         // ----- // IR Dump before convert-func-to-llvm //----- //

--- a/arnoldc/src/transform.rs
+++ b/arnoldc/src/transform.rs
@@ -136,6 +136,7 @@ mod tests {
     use indoc::indoc;
     use std::panic::Location;
     use tracing;
+    use xrcf::shared::SharedExt;
     use xrcf::tester::Tester;
     use xrcf::Passes;
 
@@ -209,7 +210,7 @@ mod tests {
                 panic!("Expected changes");
             }
         };
-        let actual = new_root_op.try_read().unwrap().to_string();
+        let actual = new_root_op.re().to_string();
         print_heading("After", &actual, &passes);
         (new_root_op, actual)
     }

--- a/arnoldc/src/transform.rs
+++ b/arnoldc/src/transform.rs
@@ -210,7 +210,7 @@ mod tests {
                 panic!("Expected changes");
             }
         };
-        let actual = new_root_op.re().to_string();
+        let actual = new_root_op.rd().to_string();
         print_heading("After", &actual, &passes);
         (new_root_op, actual)
     }

--- a/xrcf-bin/src/main.rs
+++ b/xrcf-bin/src/main.rs
@@ -39,7 +39,7 @@ fn parse_and_transform(src: &str, options: &TransformOptions) -> String {
     let module = Parser::<DefaultParserDispatch>::parse(&src).unwrap();
     let result = transform::<DefaultTransformDispatch>(module, options).unwrap();
     let result = match result {
-        RewriteResult::Changed(op) => op.op.re().to_string(),
+        RewriteResult::Changed(op) => op.op.rd().to_string(),
         RewriteResult::Unchanged => src.to_string(),
     };
     result

--- a/xrcf-bin/src/main.rs
+++ b/xrcf-bin/src/main.rs
@@ -6,6 +6,7 @@ use xrcf::convert::RewriteResult;
 use xrcf::init_subscriber;
 use xrcf::parser::DefaultParserDispatch;
 use xrcf::parser::Parser;
+use xrcf::shared::SharedExt;
 use xrcf::transform;
 use xrcf::DefaultTransformDispatch;
 use xrcf::Passes;
@@ -38,7 +39,7 @@ fn parse_and_transform(src: &str, options: &TransformOptions) -> String {
     let module = Parser::<DefaultParserDispatch>::parse(&src).unwrap();
     let result = transform::<DefaultTransformDispatch>(module, options).unwrap();
     let result = match result {
-        RewriteResult::Changed(op) => op.op.try_read().unwrap().to_string(),
+        RewriteResult::Changed(op) => op.op.re().to_string(),
         RewriteResult::Unchanged => src.to_string(),
     };
     result

--- a/xrcf/src/canonicalize.rs
+++ b/xrcf/src/canonicalize.rs
@@ -21,7 +21,7 @@ impl Rewrite for CanonicalizeOp {
         Ok(true)
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
-        let result = op.re().canonicalize();
+        let result = op.rd().canonicalize();
         Ok(result)
     }
 }
@@ -37,11 +37,11 @@ impl Rewrite for DeadCodeElimination {
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
         let readonly = op.clone();
-        let readonly = readonly.re();
+        let readonly = readonly.rd();
         if !readonly.is_pure() {
             return Ok(RewriteResult::Unchanged);
         }
-        let operation = readonly.operation().re();
+        let operation = readonly.operation().rd();
         let users = operation.users();
         match users {
             Users::HasNoOpResults => Ok(RewriteResult::Unchanged),

--- a/xrcf/src/canonicalize.rs
+++ b/xrcf/src/canonicalize.rs
@@ -6,6 +6,7 @@ use crate::convert::RewriteResult;
 use crate::ir::GuardedBlock;
 use crate::ir::Op;
 use crate::ir::Users;
+use crate::shared::SharedExt;
 use anyhow::Result;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -20,7 +21,7 @@ impl Rewrite for CanonicalizeOp {
         Ok(true)
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
-        let op = op.try_read().unwrap();
+        let op = op.re();
         let result = op.canonicalize();
         Ok(result)
     }
@@ -37,11 +38,11 @@ impl Rewrite for DeadCodeElimination {
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
         let readonly = op.clone();
-        let readonly = readonly.try_read().unwrap();
+        let readonly = readonly.re();
         if !readonly.is_pure() {
             return Ok(RewriteResult::Unchanged);
         }
-        let operation = readonly.operation().try_read().unwrap();
+        let operation = readonly.operation().re();
         let users = operation.users();
         match users {
             Users::HasNoOpResults => Ok(RewriteResult::Unchanged),

--- a/xrcf/src/canonicalize.rs
+++ b/xrcf/src/canonicalize.rs
@@ -21,8 +21,7 @@ impl Rewrite for CanonicalizeOp {
         Ok(true)
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
-        let op = op.re();
-        let result = op.canonicalize();
+        let result = op.re().canonicalize();
         Ok(result)
     }
 }

--- a/xrcf/src/convert/cf_to_llvm.rs
+++ b/xrcf/src/convert/cf_to_llvm.rs
@@ -22,7 +22,7 @@ impl Rewrite for BranchLowering {
         Ok(op.as_any().is::<cf::BranchOp>())
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
-        let op = op.re();
+        let op = op.rd();
         let op = op.as_any().downcast_ref::<cf::BranchOp>().unwrap();
         let new_op = llvm::BranchOp::from_operation_arc(op.operation().clone());
         let new_op = Shared::new(new_op.into());
@@ -41,7 +41,7 @@ impl Rewrite for CondBranchLowering {
         Ok(op.as_any().is::<cf::CondBranchOp>())
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
-        let op = op.re();
+        let op = op.rd();
         let op = op.as_any().downcast_ref::<cf::CondBranchOp>().unwrap();
         let new_op = llvm::CondBranchOp::from_operation_arc(op.operation().clone());
         let new_op = Shared::new(new_op.into());

--- a/xrcf/src/convert/cf_to_llvm.rs
+++ b/xrcf/src/convert/cf_to_llvm.rs
@@ -6,6 +6,7 @@ use crate::convert::RewriteResult;
 use crate::dialect::cf;
 use crate::dialect::llvm;
 use crate::ir::Op;
+use crate::shared::SharedExt;
 use anyhow::Result;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -20,7 +21,7 @@ impl Rewrite for BranchLowering {
         Ok(op.as_any().is::<cf::BranchOp>())
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
-        let op = op.try_read().unwrap();
+        let op = op.re();
         let op = op.as_any().downcast_ref::<cf::BranchOp>().unwrap();
         let new_op = llvm::BranchOp::from_operation_arc(op.operation().clone());
         let new_op = Arc::new(RwLock::new(new_op));
@@ -39,7 +40,7 @@ impl Rewrite for CondBranchLowering {
         Ok(op.as_any().is::<cf::CondBranchOp>())
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
-        let op = op.try_read().unwrap();
+        let op = op.re();
         let op = op.as_any().downcast_ref::<cf::CondBranchOp>().unwrap();
         let new_op = llvm::CondBranchOp::from_operation_arc(op.operation().clone());
         let new_op = Arc::new(RwLock::new(new_op));

--- a/xrcf/src/convert/cf_to_llvm.rs
+++ b/xrcf/src/convert/cf_to_llvm.rs
@@ -6,6 +6,7 @@ use crate::convert::RewriteResult;
 use crate::dialect::cf;
 use crate::dialect::llvm;
 use crate::ir::Op;
+use crate::shared::Shared;
 use crate::shared::SharedExt;
 use anyhow::Result;
 use std::sync::Arc;
@@ -24,7 +25,7 @@ impl Rewrite for BranchLowering {
         let op = op.re();
         let op = op.as_any().downcast_ref::<cf::BranchOp>().unwrap();
         let new_op = llvm::BranchOp::from_operation_arc(op.operation().clone());
-        let new_op = Arc::new(RwLock::new(new_op));
+        let new_op = Shared::new(new_op.into());
         op.replace(new_op.clone());
         Ok(RewriteResult::Changed(ChangedOp::new(new_op)))
     }
@@ -43,7 +44,7 @@ impl Rewrite for CondBranchLowering {
         let op = op.re();
         let op = op.as_any().downcast_ref::<cf::CondBranchOp>().unwrap();
         let new_op = llvm::CondBranchOp::from_operation_arc(op.operation().clone());
-        let new_op = Arc::new(RwLock::new(new_op));
+        let new_op = Shared::new(new_op.into());
         op.replace(new_op.clone());
         Ok(RewriteResult::Changed(ChangedOp::new(new_op)))
     }

--- a/xrcf/src/convert/experimental_to_mlir.rs
+++ b/xrcf/src/convert/experimental_to_mlir.rs
@@ -39,7 +39,7 @@ impl PrintLowering {
         let text = op.text().clone();
         let text = text.c_string();
         let len = text.len();
-        let name = parent.re().unique_value_name("%");
+        let name = parent.rd().unique_value_name("%");
         let typ = llvm::ArrayType::for_bytes(&text);
         let typ = Shared::new(typ.into());
         let result = const_operation.add_new_op_result(&name, typ);
@@ -55,7 +55,7 @@ impl PrintLowering {
         let mut operation = Operation::default();
         operation.set_parent(Some(parent.clone()));
         let typ = IntegerType::from_str("i16");
-        let name = parent.re().unique_value_name("%");
+        let name = parent.rd().unique_value_name("%");
         let result_type = Shared::new(typ.into());
         let result = operation.add_new_op_result(&name, result_type);
         let op = arith::ConstantOp::from_operation(operation);
@@ -69,7 +69,7 @@ impl PrintLowering {
         let mut operation = Operation::default();
         operation.set_parent(Some(parent.clone()));
         let typ = llvm::PointerType::new();
-        let name = parent.re().unique_value_name("%");
+        let name = parent.rd().unique_value_name("%");
         let result_type = Shared::new(typ.into());
         let result = operation.add_new_op_result(&name, result_type);
         let array_size = len.result(0);
@@ -158,7 +158,7 @@ impl PrintLowering {
     fn contains_printf(top_level_op: Arc<RwLock<dyn Op>>) -> bool {
         let ops = top_level_op.ops();
         for op in ops {
-            let op = op.re();
+            let op = op.rd();
             if op.is_func() {
                 let func = match op.as_any().downcast_ref::<llvm::FuncOp>() {
                     Some(func) => func,
@@ -229,12 +229,8 @@ impl Rewrite for PrintLowering {
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
         let op_clone = op.clone();
-        let set_varargs = {
-            let operands = op.operation().operands().vec();
-            let operands = operands.re();
-            1 < operands.len()
-        };
-        let op_rd = op_clone.re();
+        let set_varargs = 1 < op.operation().operands().vec().rd().len();
+        let op_rd = op_clone.rd();
         let op_rd = op_rd
             .as_any()
             .downcast_ref::<dialect::experimental::PrintfOp>()

--- a/xrcf/src/convert/func_to_llvm.rs
+++ b/xrcf/src/convert/func_to_llvm.rs
@@ -10,6 +10,7 @@ use crate::dialect::func::Func;
 use crate::dialect::llvm;
 use crate::ir::GuardedOperation;
 use crate::ir::Op;
+use crate::shared::Shared;
 use crate::shared::SharedExt;
 use anyhow::Result;
 use std::sync::Arc;
@@ -27,7 +28,7 @@ impl Rewrite for AddLowering {
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
         let op = op.re();
         let lowered = llvm::AddOp::from_operation_arc(op.operation().clone());
-        let new_op = Arc::new(RwLock::new(lowered));
+        let new_op = Shared::new(lowered.into());
         op.replace(new_op.clone());
 
         Ok(RewriteResult::Changed(ChangedOp::new(new_op)))
@@ -48,7 +49,7 @@ impl Rewrite for CallLowering {
         let op = op.as_any().downcast_ref::<func::CallOp>().unwrap();
         let mut new_op = llvm::CallOp::from_operation_arc(op.operation().clone());
         new_op.set_identifier(op.identifier().unwrap());
-        let new_op = Arc::new(RwLock::new(new_op));
+        let new_op = Shared::new(new_op.into());
         op.replace(new_op.clone());
 
         Ok(RewriteResult::Changed(ChangedOp::new(new_op)))
@@ -67,7 +68,7 @@ impl Rewrite for ConstantOpLowering {
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
         let op = op.re();
         let lowered = llvm::ConstantOp::from_operation_arc(op.operation().clone());
-        let new_op = Arc::new(RwLock::new(lowered));
+        let new_op = Shared::new(lowered.into());
         op.replace(new_op.clone());
 
         Ok(RewriteResult::Changed(ChangedOp::new(new_op)))
@@ -102,7 +103,7 @@ impl Rewrite for FuncLowering {
         let mut new_op = llvm::FuncOp::from_operation_arc(operation.clone());
         new_op.set_identifier(op.identifier().unwrap());
         new_op.set_sym_visibility(op.sym_visibility().clone());
-        let new_op = Arc::new(RwLock::new(new_op));
+        let new_op = Shared::new(new_op.into());
         op.replace(new_op.clone());
 
         Ok(RewriteResult::Changed(ChangedOp::new(new_op)))
@@ -122,7 +123,7 @@ impl Rewrite for ReturnLowering {
         let op = op.re();
         let op = op.as_any().downcast_ref::<func::ReturnOp>().unwrap();
         let lowered = llvm::ReturnOp::from_operation_arc(op.operation().clone());
-        let new_op = Arc::new(RwLock::new(lowered));
+        let new_op = Shared::new(lowered.into());
         op.replace(new_op.clone());
 
         Ok(RewriteResult::Changed(ChangedOp::new(new_op)))

--- a/xrcf/src/convert/func_to_llvm.rs
+++ b/xrcf/src/convert/func_to_llvm.rs
@@ -26,7 +26,7 @@ impl Rewrite for AddLowering {
         Ok(op.as_any().is::<arith::AddiOp>())
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
-        let op = op.re();
+        let op = op.rd();
         let lowered = llvm::AddOp::from_operation_arc(op.operation().clone());
         let new_op = Shared::new(lowered.into());
         op.replace(new_op.clone());
@@ -45,7 +45,7 @@ impl Rewrite for CallLowering {
         Ok(op.as_any().is::<func::CallOp>())
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
-        let op = op.re();
+        let op = op.rd();
         let op = op.as_any().downcast_ref::<func::CallOp>().unwrap();
         let mut new_op = llvm::CallOp::from_operation_arc(op.operation().clone());
         new_op.set_identifier(op.identifier().unwrap());
@@ -66,7 +66,7 @@ impl Rewrite for ConstantOpLowering {
         Ok(op.as_any().is::<arith::ConstantOp>())
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
-        let op = op.re();
+        let op = op.rd();
         let lowered = llvm::ConstantOp::from_operation_arc(op.operation().clone());
         let new_op = Shared::new(lowered.into());
         op.replace(new_op.clone());
@@ -85,7 +85,7 @@ impl Rewrite for FuncLowering {
         Ok(op.as_any().is::<func::FuncOp>())
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
-        let op = op.re();
+        let op = op.rd();
         let op = op.as_any().downcast_ref::<func::FuncOp>().unwrap();
         let operation = op.operation();
         {
@@ -120,7 +120,7 @@ impl Rewrite for ReturnLowering {
         Ok(op.as_any().is::<func::ReturnOp>())
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
-        let op = op.re();
+        let op = op.rd();
         let op = op.as_any().downcast_ref::<func::ReturnOp>().unwrap();
         let lowered = llvm::ReturnOp::from_operation_arc(op.operation().clone());
         let new_op = Shared::new(lowered.into());

--- a/xrcf/src/convert/func_to_llvm.rs
+++ b/xrcf/src/convert/func_to_llvm.rs
@@ -10,6 +10,7 @@ use crate::dialect::func::Func;
 use crate::dialect::llvm;
 use crate::ir::GuardedOperation;
 use crate::ir::Op;
+use crate::shared::SharedExt;
 use anyhow::Result;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -24,7 +25,7 @@ impl Rewrite for AddLowering {
         Ok(op.as_any().is::<arith::AddiOp>())
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
-        let op = op.try_read().unwrap();
+        let op = op.re();
         let lowered = llvm::AddOp::from_operation_arc(op.operation().clone());
         let new_op = Arc::new(RwLock::new(lowered));
         op.replace(new_op.clone());
@@ -43,7 +44,7 @@ impl Rewrite for CallLowering {
         Ok(op.as_any().is::<func::CallOp>())
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
-        let op = op.try_read().unwrap();
+        let op = op.re();
         let op = op.as_any().downcast_ref::<func::CallOp>().unwrap();
         let mut new_op = llvm::CallOp::from_operation_arc(op.operation().clone());
         new_op.set_identifier(op.identifier().unwrap());
@@ -64,7 +65,7 @@ impl Rewrite for ConstantOpLowering {
         Ok(op.as_any().is::<arith::ConstantOp>())
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
-        let op = op.try_read().unwrap();
+        let op = op.re();
         let lowered = llvm::ConstantOp::from_operation_arc(op.operation().clone());
         let new_op = Arc::new(RwLock::new(lowered));
         op.replace(new_op.clone());
@@ -83,7 +84,7 @@ impl Rewrite for FuncLowering {
         Ok(op.as_any().is::<func::FuncOp>())
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
-        let op = op.try_read().unwrap();
+        let op = op.re();
         let op = op.as_any().downcast_ref::<func::FuncOp>().unwrap();
         let operation = op.operation();
         {
@@ -118,7 +119,7 @@ impl Rewrite for ReturnLowering {
         Ok(op.as_any().is::<func::ReturnOp>())
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
-        let op = op.try_read().unwrap();
+        let op = op.re();
         let op = op.as_any().downcast_ref::<func::ReturnOp>().unwrap();
         let lowered = llvm::ReturnOp::from_operation_arc(op.operation().clone());
         let new_op = Arc::new(RwLock::new(lowered));

--- a/xrcf/src/convert/mlir_to_llvmir.rs
+++ b/xrcf/src/convert/mlir_to_llvmir.rs
@@ -109,10 +109,10 @@ impl Rewrite for AllocaLowering {
             .unwrap();
         let operation = op.operation();
         let mut new_op = targ3t::llvmir::AllocaOp::from_operation_arc(operation.clone());
-        {
-            let operation = operation.rd();
-            operation.results().convert_types::<ConvertMLIRToLLVMIR>()?;
-        }
+        operation
+            .rd()
+            .results()
+            .convert_types::<ConvertMLIRToLLVMIR>()?;
         new_op.set_element_type(op.element_type().unwrap());
         replace_constant_operands(&new_op);
         let new_op = Shared::new(new_op.into());
@@ -181,9 +181,8 @@ impl Rewrite for BranchLowering {
     fn is_match(&self, op: &dyn Op) -> Result<bool> {
         if op.as_any().is::<dialect::llvm::BranchOp>() {
             let operands = op.operation().operands().vec();
-            let operands = operands.rd();
             // Check whether [MergeLowering] has already removed the operands.
-            for operand in operands.iter() {
+            for operand in operands.rd().iter() {
                 let operand = operand.rd();
                 let value = operand.value();
                 let value = value.rd();

--- a/xrcf/src/convert/mlir_to_llvmir.rs
+++ b/xrcf/src/convert/mlir_to_llvmir.rs
@@ -180,19 +180,13 @@ impl Rewrite for BranchLowering {
     }
     fn is_match(&self, op: &dyn Op) -> Result<bool> {
         if op.as_any().is::<dialect::llvm::BranchOp>() {
-            let operands = op.operation().operands().vec();
             // Check whether [MergeLowering] has already removed the operands.
-            for operand in operands.rd().iter() {
+            Ok(op.operation().operands().into_iter().all(|operand| {
                 let operand = operand.rd();
                 let value = operand.value();
                 let value = value.rd();
-                match &*value {
-                    Value::BlockLabel(_) => {}
-                    Value::BlockPtr(_) => {}
-                    _ => return Ok(false),
-                }
-            }
-            Ok(true)
+                matches!(&*value, Value::BlockLabel(_) | Value::BlockPtr(_))
+            }))
         } else {
             Ok(false)
         }

--- a/xrcf/src/convert/mlir_to_llvmir.rs
+++ b/xrcf/src/convert/mlir_to_llvmir.rs
@@ -269,8 +269,7 @@ fn lower_block_argument_types(operation: &mut Operation) {
         let arguments = arguments.rd();
         let mut new_arguments = vec![];
         for argument in arguments.iter() {
-            let argument_rd = argument.rd();
-            if let Value::Variadic = &*argument_rd {
+            if let Value::Variadic = &*argument.rd() {
                 new_arguments.push(argument.clone());
             } else {
                 let typ = argument.typ().unwrap();
@@ -394,14 +393,10 @@ fn verify_argument_pairs(pairs: &Vec<(Arc<RwLock<OpOperand>>, Arc<RwLock<Block>>
     }
     let mut typ: Option<Arc<RwLock<dyn Type>>> = None;
     for (op_operand, _) in pairs.iter() {
-        let op_operand = op_operand.rd();
-        let value = op_operand.value();
-        let value_typ = value.typ().unwrap();
+        let value_typ = op_operand.rd().value().typ().unwrap();
         if let Some(typ) = &typ {
-            let typ = typ.rd();
-            let value_typ = value_typ.rd();
-            let value_typ = value_typ.to_string();
-            let typ = typ.to_string();
+            let typ = typ.rd().to_string();
+            let value_typ = value_typ.rd().to_string();
             if typ != value_typ {
                 panic!("Expected same type, but got {typ} and {value_typ}");
             }

--- a/xrcf/src/convert/mlir_to_llvmir.rs
+++ b/xrcf/src/convert/mlir_to_llvmir.rs
@@ -29,7 +29,7 @@ use crate::ir::Types;
 use crate::ir::Users;
 use crate::ir::Value;
 use crate::ir::Values;
-use crate::shared::RwLockExt;
+use crate::shared::SharedExt;
 use crate::targ3t;
 use anyhow::Result;
 use std::sync::Arc;

--- a/xrcf/src/convert/mlir_to_llvmir.rs
+++ b/xrcf/src/convert/mlir_to_llvmir.rs
@@ -160,8 +160,7 @@ impl Rewrite for BlockLowering {
         Ok(false)
     }
     fn rewrite(&self, op: Arc<RwLock<dyn Op>>) -> Result<RewriteResult> {
-        let blocks = op.operation().blocks();
-        for block in blocks.iter() {
+        for block in op.operation().rd().blocks().into_iter() {
             block.set_label_prefix("".to_string());
         }
         Ok(RewriteResult::Changed(ChangedOp::new(op)))
@@ -517,8 +516,7 @@ impl Rewrite for MergeLowering {
         if operation.region().is_none() {
             return Ok(false);
         }
-        let blocks = operation.blocks();
-        for block in blocks.iter() {
+        for block in operation.rd().blocks().into_iter() {
             let block = block.rd();
             let has_argument = !block.arguments().vec().rd().is_empty();
             if has_argument {

--- a/xrcf/src/convert/mod.rs
+++ b/xrcf/src/convert/mod.rs
@@ -87,7 +87,7 @@ fn apply_rewrites_helper(
     rewrites: &[&dyn Rewrite],
     indent: i32,
 ) -> Result<RewriteResult> {
-    let ops = root.re().ops();
+    let ops = root.rd().ops();
     for rewrite in rewrites {
         // Determine ops here because `rewrite` may delete an op.
         for nested_op in ops.iter() {
@@ -102,11 +102,11 @@ fn apply_rewrites_helper(
         debug!(
             "{}Matching {} with {}",
             spaces(indent),
-            root.clone().re().name(),
+            root.clone().rd().name(),
             rewrite.name()
         );
         let root_read = root.clone();
-        let root_read = root_read.re();
+        let root_read = root_read.rd();
         if rewrite.is_match(&*root_read)? {
             debug!("{}--> Success", spaces(indent));
             let root_rewrite = rewrite.rewrite(root.clone())?;

--- a/xrcf/src/convert/mod.rs
+++ b/xrcf/src/convert/mod.rs
@@ -7,6 +7,7 @@
 
 use crate::ir::spaces;
 use crate::ir::Op;
+use crate::shared::SharedExt;
 use anyhow::Result;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -86,7 +87,7 @@ fn apply_rewrites_helper(
     rewrites: &[&dyn Rewrite],
     indent: i32,
 ) -> Result<RewriteResult> {
-    let ops = root.try_read().unwrap().ops();
+    let ops = root.re().ops();
     for rewrite in rewrites {
         // Determine ops here because `rewrite` may delete an op.
         for nested_op in ops.iter() {
@@ -101,11 +102,11 @@ fn apply_rewrites_helper(
         debug!(
             "{}Matching {} with {}",
             spaces(indent),
-            root.clone().try_read().unwrap().name(),
+            root.clone().re().name(),
             rewrite.name()
         );
         let root_read = root.clone();
-        let root_read = root_read.try_read().unwrap();
+        let root_read = root_read.re();
         if rewrite.is_match(&*root_read)? {
             debug!("{}--> Success", spaces(indent));
             let root_rewrite = rewrite.rewrite(root.clone())?;

--- a/xrcf/src/convert/scf_to_cf.rs
+++ b/xrcf/src/convert/scf_to_cf.rs
@@ -180,13 +180,11 @@ fn add_exit_block(
 ///
 /// Necessary to translate `%result = scf.if` to `^merge:(%result)`.
 fn as_block_arguments(results: Values, parent: Arc<RwLock<Block>>) -> Result<Values> {
-    let results = results.vec();
-    let results = results.rd();
     let mut out = vec![];
-    for result in results.iter() {
-        let result = result.rd();
-        let name = result.name();
-        let typ = result.typ().unwrap();
+    for result in results.into_iter() {
+        let result_rd = result.rd();
+        let name = result_rd.name();
+        let typ = result_rd.typ().unwrap();
         let name = BlockArgumentName::Name(name.unwrap());
         let name = Shared::new(name.into());
         let mut arg = BlockArgument::new(name, typ);
@@ -199,13 +197,9 @@ fn as_block_arguments(results: Values, parent: Arc<RwLock<Block>>) -> Result<Val
 }
 
 fn results_users(results: Values) -> Vec<Users> {
-    let results = results.vec();
-    let results = results.rd();
     let mut out = vec![];
-    for result in results.iter() {
-        let result = result.rd();
-        let users = result.users();
-        out.push(users);
+    for result in results.into_iter() {
+        out.push(result.rd().users());
     }
     out
 }

--- a/xrcf/src/convert/scf_to_cf.rs
+++ b/xrcf/src/convert/scf_to_cf.rs
@@ -19,7 +19,7 @@ use crate::ir::Region;
 use crate::ir::Users;
 use crate::ir::Value;
 use crate::ir::Values;
-use crate::shared::RwLockExt;
+use crate::shared::SharedExt;
 use anyhow::Result;
 use std::sync::Arc;
 use std::sync::RwLock;

--- a/xrcf/src/convert/scf_to_cf.rs
+++ b/xrcf/src/convert/scf_to_cf.rs
@@ -19,6 +19,7 @@ use crate::ir::Region;
 use crate::ir::Users;
 use crate::ir::Value;
 use crate::ir::Values;
+use crate::shared::RwLockExt;
 use anyhow::Result;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -82,7 +83,7 @@ fn branch_op(after: Arc<RwLock<Block>>) -> Arc<RwLock<dyn Op>> {
 /// Add a `cf.br` to the end of `block` with destination `after`.
 fn add_branch_to_after(block: Arc<RwLock<Block>>, after: Arc<RwLock<Block>>) {
     let ops = block.ops();
-    let mut ops = ops.try_write().unwrap();
+    let mut ops = ops.wr();
     let ops_clone = ops.clone();
     let last_op = ops_clone.last().unwrap();
     let last_op = last_op.try_read().unwrap();
@@ -129,7 +130,7 @@ fn move_successors_to_exit_block(
         .index_of(&op.operation().try_read().unwrap())
         .expect("Expected index");
     let ops = if_op_parent.ops();
-    let mut ops = ops.try_write().unwrap();
+    let mut ops = ops.wr();
     let return_ops = ops[if_op_index + 1..].to_vec();
     for op in return_ops.iter() {
         let op = op.try_read().unwrap();
@@ -270,7 +271,7 @@ fn add_blocks(
             println!("users.len: {}", users.len());
             let arg = merge_block_arguments[i].clone();
             for user in users.iter() {
-                let mut user = user.try_write().unwrap();
+                let mut user = user.wr();
                 user.set_value(arg.clone());
             }
         }

--- a/xrcf/src/dialect/arith/op.rs
+++ b/xrcf/src/dialect/arith/op.rs
@@ -18,7 +18,7 @@ use crate::parser::Parse;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
-use crate::shared::RwLockExt;
+use crate::shared::SharedExt;
 use anyhow::Result;
 use std::fmt::Display;
 use std::fmt::Formatter;

--- a/xrcf/src/dialect/arith/op.rs
+++ b/xrcf/src/dialect/arith/op.rs
@@ -127,7 +127,7 @@ impl AddiOp {
     fn addi_add_constant(&self) -> RewriteResult {
         let operands = self.operation.operands();
         let operands = operands.vec();
-        let operands = operands.try_read().unwrap();
+        let operands = operands.re();
         assert!(operands.len() == 2);
 
         let lhs = operands.get(0).unwrap();
@@ -185,11 +185,11 @@ impl AddiOp {
         self.replace(new_const.clone());
 
         {
-            let new_const = new_const.try_read().unwrap();
-            let new_const = new_const.operation().try_read().unwrap();
+            let new_const = new_const.re();
+            let new_const = new_const.operation().re();
             let results = new_const.results();
             let results = results.vec();
-            let results = results.try_read().unwrap();
+            let results = results.re();
             assert!(results.len() == 1);
             results[0].rename("%c3_i64");
         }

--- a/xrcf/src/dialect/arith/op.rs
+++ b/xrcf/src/dialect/arith/op.rs
@@ -137,7 +137,7 @@ impl AddiOp {
                 return RewriteResult::Unchanged;
             }
         };
-        let lhs = lhs.read().unwrap();
+        let lhs = lhs.re();
         let lhs = match lhs.as_any().downcast_ref::<ConstantOp>() {
             Some(lhs) => lhs,
             None => return RewriteResult::Unchanged,
@@ -148,7 +148,7 @@ impl AddiOp {
             Some(rhs) => rhs,
             None => return RewriteResult::Unchanged,
         };
-        let rhs = rhs.read().unwrap();
+        let rhs = rhs.re();
         let rhs = match rhs.as_any().downcast_ref::<ConstantOp>() {
             Some(rhs) => rhs,
             None => return RewriteResult::Unchanged,

--- a/xrcf/src/dialect/arith/op.rs
+++ b/xrcf/src/dialect/arith/op.rs
@@ -18,6 +18,7 @@ use crate::parser::Parse;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
+use crate::shared::RwLockExt;
 use anyhow::Result;
 use std::fmt::Display;
 use std::fmt::Formatter;
@@ -171,12 +172,12 @@ impl AddiOp {
         result.set_name("%c3_i64");
         let result = Value::OpResult(result);
         let result = Arc::new(RwLock::new(result));
-        results.vec().try_write().unwrap().push(result.clone());
+        results.vec().wr().push(result.clone());
         new_operation.set_results(results);
 
         let new_const = ConstantOp::from_operation(new_operation);
         let new_const = Arc::new(RwLock::new(new_const));
-        let mut result = result.try_write().unwrap();
+        let mut result = result.wr();
         if let Value::OpResult(result) = &mut *result {
             result.set_defining_op(Some(new_const.clone()));
         }

--- a/xrcf/src/dialect/arith/op.rs
+++ b/xrcf/src/dialect/arith/op.rs
@@ -18,6 +18,7 @@ use crate::parser::Parse;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
+use crate::shared::Shared;
 use crate::shared::SharedExt;
 use anyhow::Result;
 use std::fmt::Display;

--- a/xrcf/src/dialect/arith/op.rs
+++ b/xrcf/src/dialect/arith/op.rs
@@ -128,7 +128,7 @@ impl AddiOp {
     fn addi_add_constant(&self) -> RewriteResult {
         let operands = self.operation.operands();
         let operands = operands.vec();
-        let operands = operands.re();
+        let operands = operands.rd();
         assert!(operands.len() == 2);
 
         let lhs = operands.get(0).unwrap();
@@ -138,7 +138,7 @@ impl AddiOp {
                 return RewriteResult::Unchanged;
             }
         };
-        let lhs = lhs.re();
+        let lhs = lhs.rd();
         let lhs = match lhs.as_any().downcast_ref::<ConstantOp>() {
             Some(lhs) => lhs,
             None => return RewriteResult::Unchanged,
@@ -149,7 +149,7 @@ impl AddiOp {
             Some(rhs) => rhs,
             None => return RewriteResult::Unchanged,
         };
-        let rhs = rhs.re();
+        let rhs = rhs.rd();
         let rhs = match rhs.as_any().downcast_ref::<ConstantOp>() {
             Some(rhs) => rhs,
             None => return RewriteResult::Unchanged,
@@ -186,11 +186,11 @@ impl AddiOp {
         self.replace(new_const.clone());
 
         {
-            let new_const = new_const.re();
-            let new_const = new_const.operation().re();
+            let new_const = new_const.rd();
+            let new_const = new_const.operation().rd();
             let results = new_const.results();
             let results = results.vec();
-            let results = results.re();
+            let results = results.rd();
             assert!(results.len() == 1);
             results[0].rename("%c3_i64");
         }

--- a/xrcf/src/dialect/arith/op.rs
+++ b/xrcf/src/dialect/arith/op.rs
@@ -89,7 +89,7 @@ impl Parse for ConstantOp {
 
         let value = if parser.is_boolean() {
             let typ = IntegerType::new(1);
-            let typ = Arc::new(RwLock::new(typ));
+            let typ = Shared::new(typ.into());
             operation.set_result_type(0, typ)?;
             parser.parse_boolean()?
         } else {
@@ -103,10 +103,10 @@ impl Parse for ConstantOp {
             Arc::new(integer)
         };
 
-        let operation = Arc::new(RwLock::new(operation));
+        let operation = Shared::new(operation.into());
         let op = ConstantOp { operation };
         op.set_value(value);
-        let op = Arc::new(RwLock::new(op));
+        let op = Shared::new(op.into());
         results.set_defining_op(op.clone());
         Ok(op)
     }
@@ -171,12 +171,12 @@ impl AddiOp {
         let result = OpResult::default();
         result.set_name("%c3_i64");
         let result = Value::OpResult(result);
-        let result = Arc::new(RwLock::new(result));
+        let result = Shared::new(result.into());
         results.vec().wr().push(result.clone());
         new_operation.set_results(results);
 
         let new_const = ConstantOp::from_operation(new_operation);
-        let new_const = Arc::new(RwLock::new(new_const));
+        let new_const = Shared::new(new_const.into());
         let mut result = result.wr();
         if let Value::OpResult(result) = &mut *result {
             result.set_defining_op(Some(new_const.clone()));
@@ -234,11 +234,11 @@ impl<T: ParserDispatch> Parser<T> {
         let _colon = parser.expect(TokenKind::Colon)?;
         let result_type = parser.expect(TokenKind::IntType)?;
         let result_type = AnyType::new(&result_type.lexeme);
-        let result_type = Arc::new(RwLock::new(result_type));
+        let result_type = Shared::new(result_type.into());
         operation.set_result_type(0, result_type)?;
 
         let op = O::from_operation(operation);
-        let op = Arc::new(RwLock::new(op));
+        let op = Shared::new(op.into());
         results.set_defining_op(op.clone());
         Ok(op)
     }

--- a/xrcf/src/dialect/cf/op.rs
+++ b/xrcf/src/dialect/cf/op.rs
@@ -54,16 +54,16 @@ impl Op for BranchOp {
     fn display(&self, f: &mut Formatter<'_>, _indent: i32) -> std::fmt::Result {
         write!(f, "{} ", self.operation.name())?;
         let dest = self.dest().expect("Dest not set");
-        let dest = dest.try_read().unwrap();
+        let dest = dest.re();
         write!(f, "{}", dest)?;
         let operands = self.operation().operands();
         let operands = operands.vec();
-        let operands = operands.try_read().unwrap();
+        let operands = operands.re();
         let operands = operands.iter().skip(1);
         if 0 < operands.len() {
             write!(f, "(")?;
             for operand in operands {
-                let operand = operand.try_read().unwrap();
+                let operand = operand.re();
                 operand.display_with_type(f)?;
             }
             write!(f, ")")?;

--- a/xrcf/src/dialect/cf/op.rs
+++ b/xrcf/src/dialect/cf/op.rs
@@ -81,10 +81,10 @@ impl Parse for BranchOp {
         operation.set_parent(parent.clone());
         parser.parse_operation_name_into::<BranchOp>(&mut operation)?;
         let dest = parser.parse_block_dest()?;
-        let dest = Arc::new(RwLock::new(dest));
+        let dest = Shared::new(dest.into());
         operation.set_operand(0, dest);
 
-        let operation = Arc::new(RwLock::new(operation));
+        let operation = Shared::new(operation.into());
 
         if parser.check(TokenKind::LParen) {
             parser.expect(TokenKind::LParen)?;
@@ -103,7 +103,7 @@ impl Parse for BranchOp {
         }
 
         let op = BranchOp { operation };
-        let op = Arc::new(RwLock::new(op));
+        let op = Shared::new(op.into());
         Ok(op)
     }
 }
@@ -147,9 +147,9 @@ impl Parse for CondBranchOp {
         parser.parse_operation_name_into::<CondBranchOp>(&mut operation)?;
         parser.parse_op_operands_into(parent.clone().unwrap(), TOKEN_KIND, &mut operation)?;
 
-        let operation = Arc::new(RwLock::new(operation));
+        let operation = Shared::new(operation.into());
         let op = CondBranchOp { operation };
-        let op = Arc::new(RwLock::new(op));
+        let op = Shared::new(op.into());
         Ok(op)
     }
 }

--- a/xrcf/src/dialect/cf/op.rs
+++ b/xrcf/src/dialect/cf/op.rs
@@ -8,6 +8,7 @@ use crate::parser::Parse;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
+use crate::shared::Shared;
 use crate::shared::SharedExt;
 use anyhow::Result;
 use std::fmt::Display;

--- a/xrcf/src/dialect/cf/op.rs
+++ b/xrcf/src/dialect/cf/op.rs
@@ -8,6 +8,7 @@ use crate::parser::Parse;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
+use crate::shared::RwLockExt;
 use anyhow::Result;
 use std::fmt::Display;
 use std::fmt::Formatter;
@@ -88,7 +89,7 @@ impl Parse for BranchOp {
         if parser.check(TokenKind::LParen) {
             parser.expect(TokenKind::LParen)?;
             let operands = operation.operands().vec();
-            let mut operands = operands.try_write().unwrap();
+            let mut operands = operands.wr();
             loop {
                 let operand = parser.parse_op_operand(parent.clone().unwrap(), TOKEN_KIND)?;
                 operands.push(operand.clone());

--- a/xrcf/src/dialect/cf/op.rs
+++ b/xrcf/src/dialect/cf/op.rs
@@ -8,7 +8,7 @@ use crate::parser::Parse;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
-use crate::shared::RwLockExt;
+use crate::shared::SharedExt;
 use anyhow::Result;
 use std::fmt::Display;
 use std::fmt::Formatter;

--- a/xrcf/src/dialect/cf/op.rs
+++ b/xrcf/src/dialect/cf/op.rs
@@ -55,16 +55,16 @@ impl Op for BranchOp {
     fn display(&self, f: &mut Formatter<'_>, _indent: i32) -> std::fmt::Result {
         write!(f, "{} ", self.operation.name())?;
         let dest = self.dest().expect("Dest not set");
-        let dest = dest.re();
+        let dest = dest.rd();
         write!(f, "{}", dest)?;
         let operands = self.operation().operands();
         let operands = operands.vec();
-        let operands = operands.re();
+        let operands = operands.rd();
         let operands = operands.iter().skip(1);
         if 0 < operands.len() {
             write!(f, "(")?;
             for operand in operands {
-                let operand = operand.re();
+                let operand = operand.rd();
                 operand.display_with_type(f)?;
             }
             write!(f, ")")?;

--- a/xrcf/src/dialect/cf/op.rs
+++ b/xrcf/src/dialect/cf/op.rs
@@ -54,18 +54,12 @@ impl Op for BranchOp {
     }
     fn display(&self, f: &mut Formatter<'_>, _indent: i32) -> std::fmt::Result {
         write!(f, "{} ", self.operation.name())?;
-        let dest = self.dest().expect("Dest not set");
-        let dest = dest.rd();
-        write!(f, "{}", dest)?;
-        let operands = self.operation().operands();
-        let operands = operands.vec();
-        let operands = operands.rd();
-        let operands = operands.iter().skip(1);
+        write!(f, "{}", self.dest().expect("dest not set").rd())?;
+        let operands = self.operation().operands().into_iter().skip(1);
         if 0 < operands.len() {
             write!(f, "(")?;
             for operand in operands {
-                let operand = operand.rd();
-                operand.display_with_type(f)?;
+                operand.rd().display_with_type(f)?;
             }
             write!(f, ")")?;
         }

--- a/xrcf/src/dialect/experimental/op.rs
+++ b/xrcf/src/dialect/experimental/op.rs
@@ -32,9 +32,9 @@ impl PrintfOp {
     pub fn text(&self) -> StringAttr {
         let operands = self.operation.operand(0);
         let operand = operands.expect("no operand");
-        let operand = operand.re();
+        let operand = operand.rd();
         let value = operand.value();
-        let value = value.re();
+        let value = value.rd();
         let text = match &*value {
             Value::Constant(constant) => constant,
             _ => panic!("expected constant"),

--- a/xrcf/src/dialect/experimental/op.rs
+++ b/xrcf/src/dialect/experimental/op.rs
@@ -46,9 +46,9 @@ impl PrintfOp {
     pub fn set_text(&mut self, text: StringAttr) {
         let value = Constant::new(Arc::new(text));
         let value = Value::Constant(value);
-        let value = Arc::new(RwLock::new(value));
+        let value = Shared::new(value.into());
         let operand = OpOperand::new(value);
-        let operand = Arc::new(RwLock::new(operand));
+        let operand = Shared::new(operand.into());
         self.operation.set_operand(0, operand);
     }
 }
@@ -85,9 +85,9 @@ impl Parse for PrintfOp {
         parser.expect(TokenKind::LParen)?;
         parser.parse_op_operands_into(parent.expect("no parent"), TOKEN_KIND, &mut operation)?;
         parser.expect(TokenKind::RParen)?;
-        let operation = Arc::new(RwLock::new(operation));
+        let operation = Shared::new(operation.into());
         let op = PrintfOp { operation };
 
-        Ok(Arc::new(RwLock::new(op)))
+        Ok(Shared::new(op.into()))
     }
 }

--- a/xrcf/src/dialect/experimental/op.rs
+++ b/xrcf/src/dialect/experimental/op.rs
@@ -11,6 +11,7 @@ use crate::parser::Parse;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
+use crate::shared::Shared;
 use crate::shared::SharedExt;
 use anyhow::Result;
 use std::fmt::Formatter;

--- a/xrcf/src/dialect/experimental/op.rs
+++ b/xrcf/src/dialect/experimental/op.rs
@@ -32,16 +32,17 @@ impl PrintfOp {
     pub fn text(&self) -> StringAttr {
         let operands = self.operation.operand(0);
         let operand = operands.expect("no operand");
-        let operand = operand.rd();
-        let value = operand.value();
+        let value = operand.rd().value();
         let value = value.rd();
-        let text = match &*value {
-            Value::Constant(constant) => constant,
+        match &*value {
+            Value::Constant(constant) => constant
+                .value()
+                .as_any()
+                .downcast_ref::<StringAttr>()
+                .unwrap()
+                .clone(),
             _ => panic!("expected constant"),
-        };
-        let text = text.value();
-        let text = text.as_any().downcast_ref::<StringAttr>().unwrap();
-        text.clone()
+        }
     }
     /// Set the first operand to `printf`.
     pub fn set_text(&mut self, text: StringAttr) {

--- a/xrcf/src/dialect/experimental/op.rs
+++ b/xrcf/src/dialect/experimental/op.rs
@@ -11,6 +11,7 @@ use crate::parser::Parse;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
+use crate::shared::SharedExt;
 use anyhow::Result;
 use std::fmt::Formatter;
 use std::sync::Arc;
@@ -30,9 +31,9 @@ impl PrintfOp {
     pub fn text(&self) -> StringAttr {
         let operands = self.operation.operand(0);
         let operand = operands.expect("no operand");
-        let operand = operand.try_read().unwrap();
+        let operand = operand.re();
         let value = operand.value();
-        let value = value.try_read().unwrap();
+        let value = value.re();
         let text = match &*value {
             Value::Constant(constant) => constant,
             _ => panic!("expected constant"),

--- a/xrcf/src/dialect/func/op.rs
+++ b/xrcf/src/dialect/func/op.rs
@@ -19,6 +19,7 @@ use crate::parser::Parse;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
+use crate::shared::RwLockExt;
 use anyhow::Result;
 use std::fmt::Formatter;
 use std::sync::Arc;
@@ -210,7 +211,7 @@ pub trait Func: Op {
     fn set_sym_visibility(&mut self, visibility: Option<String>) {
         if let Some(visibility) = visibility {
             let operation = self.operation();
-            let operation = operation.try_write().unwrap();
+            let operation = operation.wr();
             let attributes = operation.attributes();
             let attribute = StringAttr::from_str(&visibility);
             let attribute = Arc::new(attribute);

--- a/xrcf/src/dialect/func/op.rs
+++ b/xrcf/src/dialect/func/op.rs
@@ -44,7 +44,7 @@ pub trait Call: Op {
     fn varargs(&self) -> Option<Arc<RwLock<dyn Type>>>;
     fn set_varargs(&mut self, varargs: Option<Arc<RwLock<dyn Type>>>);
     fn display_call_op(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let operation = self.operation().read().unwrap();
+        let operation = self.operation().re();
         let results = operation.results();
         let has_results = !results.vec().re().is_empty();
         if has_results {
@@ -220,7 +220,7 @@ pub trait Func: Op {
     }
     fn arguments(&self) -> Result<Values> {
         let operation = self.operation();
-        let operation = operation.read().unwrap();
+        let operation = operation.re();
         let arguments = operation.arguments();
         Ok(arguments.clone())
     }
@@ -448,7 +448,7 @@ impl ReturnOp {
         let operands = operands.re();
         if !operands.is_empty() {
             for operand in operands.iter() {
-                write!(f, " {}", operand.read().unwrap())?;
+                write!(f, " {}", operand.re())?;
             }
             let result_types = operation.results().types();
             write!(f, " : {}", result_types)?;

--- a/xrcf/src/dialect/func/op.rs
+++ b/xrcf/src/dialect/func/op.rs
@@ -19,7 +19,7 @@ use crate::parser::Parse;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
-use crate::shared::RwLockExt;
+use crate::shared::SharedExt;
 use anyhow::Result;
 use std::fmt::Formatter;
 use std::sync::Arc;

--- a/xrcf/src/dialect/func/op.rs
+++ b/xrcf/src/dialect/func/op.rs
@@ -132,7 +132,7 @@ pub trait Call: Op {
         let mut op = O::from_operation(operation);
         op.set_identifier(identifier);
         op.set_varargs(varargs);
-        let op = Arc::new(RwLock::new(op));
+        let op = Shared::new(op.into());
         results.set_defining_op(op.clone());
         Ok(op)
     }
@@ -257,10 +257,10 @@ impl FuncOp {
                 panic!("Expected region to be empty");
             }
             let ops = vec![op.clone()];
-            let ops = Arc::new(RwLock::new(ops));
+            let ops = Shared::new(ops.into());
             let region = Region::default();
             let without_parent = region.add_empty_block();
-            let region = Arc::new(RwLock::new(region));
+            let region = Shared::new(region.into());
             let block = without_parent.set_parent(Some(region.clone()));
             block.set_ops(ops);
             operation.set_region(Some(region));
@@ -381,7 +381,7 @@ impl<T: ParserDispatch> Parser<T> {
             while self.check(TokenKind::IntType) {
                 let typ = self.advance();
                 let typ = AnyType::new(&typ.lexeme);
-                let typ = Arc::new(RwLock::new(typ));
+                let typ = Shared::new(typ.into());
                 result_types.push(typ);
             }
         }
@@ -404,7 +404,7 @@ impl<T: ParserDispatch> Parser<T> {
         let mut op = F::from_operation(operation);
         op.set_identifier(identifier);
         op.set_sym_visibility(visibility);
-        let op = Arc::new(RwLock::new(op));
+        let op = Shared::new(op.into());
         let has_implementation = parser.check(TokenKind::LBrace);
         if has_implementation {
             let region = parser.parse_region(op.clone())?;
@@ -490,11 +490,11 @@ impl<T: ParserDispatch> Parser<T> {
             self.expect(TokenKind::Colon)?;
             let return_type = self.expect(TokenKind::IntType)?;
             let return_type = IntegerType::from_str(&return_type.lexeme);
-            let result_type = Arc::new(RwLock::new(return_type));
+            let result_type = Shared::new(return_type.into());
             operation.set_anonymous_result(result_type)?;
         }
         let op = O::from_operation(operation);
-        let op = Arc::new(RwLock::new(op));
+        let op = Shared::new(op.into());
         Ok(op)
     }
 }

--- a/xrcf/src/dialect/func/op.rs
+++ b/xrcf/src/dialect/func/op.rs
@@ -49,22 +49,23 @@ pub trait Call: Op {
         let results = operation.results();
         let has_results = !results.vec().rd().is_empty();
         if has_results {
-            write!(f, "{} = ", operation.results())?;
+            write!(f, "{} = ", results)?;
         }
         write!(f, "{}", operation.name())?;
         write!(f, " {}", self.identifier().unwrap())?;
         write!(f, "({})", operation.operands())?;
         if let Some(varargs) = self.varargs() {
-            let varargs = varargs.rd();
-            write!(f, " vararg({})", varargs)?;
+            write!(f, " vararg({})", varargs.rd())?;
         }
         write!(f, " : ")?;
         write!(f, "({})", operation.operand_types())?;
         write!(f, " -> ")?;
         if has_results {
-            let result_type = operation.result_type(0).expect("no result type");
-            let result_type = result_type.rd();
-            write!(f, "{}", result_type)?;
+            write!(
+                f,
+                "{}",
+                operation.result_type(0).expect("no result type").rd()
+            )?;
         } else {
             write!(f, "()")?;
         }
@@ -220,10 +221,7 @@ pub trait Func: Op {
         }
     }
     fn arguments(&self) -> Result<Values> {
-        let operation = self.operation();
-        let operation = operation.rd();
-        let arguments = operation.arguments();
-        Ok(arguments.clone())
+        Ok(self.operation().rd().arguments().clone())
     }
     fn return_types(&self) -> Vec<Arc<RwLock<dyn Type>>> {
         self.operation().results().types().vec()

--- a/xrcf/src/dialect/func/op.rs
+++ b/xrcf/src/dialect/func/op.rs
@@ -45,9 +45,9 @@ pub trait Call: Op {
     fn varargs(&self) -> Option<Arc<RwLock<dyn Type>>>;
     fn set_varargs(&mut self, varargs: Option<Arc<RwLock<dyn Type>>>);
     fn display_call_op(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let operation = self.operation().re();
+        let operation = self.operation().rd();
         let results = operation.results();
-        let has_results = !results.vec().re().is_empty();
+        let has_results = !results.vec().rd().is_empty();
         if has_results {
             write!(f, "{} = ", operation.results())?;
         }
@@ -55,7 +55,7 @@ pub trait Call: Op {
         write!(f, " {}", self.identifier().unwrap())?;
         write!(f, "({})", operation.operands())?;
         if let Some(varargs) = self.varargs() {
-            let varargs = varargs.re();
+            let varargs = varargs.rd();
             write!(f, " vararg({})", varargs)?;
         }
         write!(f, " : ")?;
@@ -63,7 +63,7 @@ pub trait Call: Op {
         write!(f, " -> ")?;
         if has_results {
             let result_type = operation.result_type(0).expect("no result type");
-            let result_type = result_type.re();
+            let result_type = result_type.rd();
             write!(f, "{}", result_type)?;
         } else {
             write!(f, "()")?;
@@ -116,7 +116,7 @@ pub trait Call: Op {
 
         // (i32) or (!llvm.ptr, i32)
         parser.expect(TokenKind::LParen)?;
-        if !operands.vec().re().is_empty() {
+        if !operands.vec().rd().is_empty() {
             parser.parse_types_for_op_operands(operands)?;
         }
         parser.expect(TokenKind::RParen)?;
@@ -221,7 +221,7 @@ pub trait Func: Op {
     }
     fn arguments(&self) -> Result<Values> {
         let operation = self.operation();
-        let operation = operation.re();
+        let operation = operation.rd();
         let arguments = operation.arguments();
         Ok(arguments.clone())
     }
@@ -249,7 +249,7 @@ pub struct FuncOp {
 impl FuncOp {
     /// Insert `op` into the region of `self`, while creating a region if necessary.
     pub fn insert_op(&self, op: Arc<RwLock<dyn Op>>) -> UnsetOp {
-        let read = op.re();
+        let read = op.rd();
         let ops = read.ops();
         if ops.is_empty() {
             let operation = self.operation();
@@ -302,7 +302,7 @@ impl FuncOp {
         f: &mut Formatter<'_>,
         indent: i32,
     ) -> std::fmt::Result {
-        let name = op.operation().re().name();
+        let name = op.operation().rd().name();
         write!(f, "{name} ")?;
         if let Some(visibility) = FuncOp::display_visibility(op) {
             write!(f, "{visibility} ")?;
@@ -409,7 +409,7 @@ impl<T: ParserDispatch> Parser<T> {
         let has_implementation = parser.check(TokenKind::LBrace);
         if has_implementation {
             let region = parser.parse_region(op.clone())?;
-            let op_rd = op.re();
+            let op_rd = op.rd();
             op_rd.operation().set_region(Some(region.clone()));
             region.set_parent(Some(op.clone()));
 
@@ -446,10 +446,10 @@ impl ReturnOp {
         let name = operation.name();
         write!(f, "{name}")?;
         let operands = operation.operands().vec();
-        let operands = operands.re();
+        let operands = operands.rd();
         if !operands.is_empty() {
             for operand in operands.iter() {
-                write!(f, " {}", operand.re())?;
+                write!(f, " {}", operand.rd())?;
             }
             let result_types = operation.results().types();
             write!(f, " : {}", result_types)?;

--- a/xrcf/src/dialect/func/op.rs
+++ b/xrcf/src/dialect/func/op.rs
@@ -46,7 +46,7 @@ pub trait Call: Op {
     fn display_call_op(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let operation = self.operation().read().unwrap();
         let results = operation.results();
-        let has_results = !results.vec().try_read().unwrap().is_empty();
+        let has_results = !results.vec().re().is_empty();
         if has_results {
             write!(f, "{} = ", operation.results())?;
         }
@@ -54,7 +54,7 @@ pub trait Call: Op {
         write!(f, " {}", self.identifier().unwrap())?;
         write!(f, "({})", operation.operands())?;
         if let Some(varargs) = self.varargs() {
-            let varargs = varargs.try_read().unwrap();
+            let varargs = varargs.re();
             write!(f, " vararg({})", varargs)?;
         }
         write!(f, " : ")?;
@@ -62,7 +62,7 @@ pub trait Call: Op {
         write!(f, " -> ")?;
         if has_results {
             let result_type = operation.result_type(0).expect("no result type");
-            let result_type = result_type.try_read().unwrap();
+            let result_type = result_type.re();
             write!(f, "{}", result_type)?;
         } else {
             write!(f, "()")?;
@@ -115,7 +115,7 @@ pub trait Call: Op {
 
         // (i32) or (!llvm.ptr, i32)
         parser.expect(TokenKind::LParen)?;
-        if !operands.vec().try_read().unwrap().is_empty() {
+        if !operands.vec().re().is_empty() {
             parser.parse_types_for_op_operands(operands)?;
         }
         parser.expect(TokenKind::RParen)?;
@@ -248,7 +248,7 @@ pub struct FuncOp {
 impl FuncOp {
     /// Insert `op` into the region of `self`, while creating a region if necessary.
     pub fn insert_op(&self, op: Arc<RwLock<dyn Op>>) -> UnsetOp {
-        let read = op.try_read().unwrap();
+        let read = op.re();
         let ops = read.ops();
         if ops.is_empty() {
             let operation = self.operation();
@@ -301,7 +301,7 @@ impl FuncOp {
         f: &mut Formatter<'_>,
         indent: i32,
     ) -> std::fmt::Result {
-        let name = op.operation().try_read().unwrap().name();
+        let name = op.operation().re().name();
         write!(f, "{name} ")?;
         if let Some(visibility) = FuncOp::display_visibility(op) {
             write!(f, "{visibility} ")?;
@@ -408,7 +408,7 @@ impl<T: ParserDispatch> Parser<T> {
         let has_implementation = parser.check(TokenKind::LBrace);
         if has_implementation {
             let region = parser.parse_region(op.clone())?;
-            let op_rd = op.try_read().unwrap();
+            let op_rd = op.re();
             op_rd.operation().set_region(Some(region.clone()));
             region.set_parent(Some(op.clone()));
 
@@ -445,7 +445,7 @@ impl ReturnOp {
         let name = operation.name();
         write!(f, "{name}")?;
         let operands = operation.operands().vec();
-        let operands = operands.try_read().unwrap();
+        let operands = operands.re();
         if !operands.is_empty() {
             for operand in operands.iter() {
                 write!(f, " {}", operand.read().unwrap())?;

--- a/xrcf/src/dialect/func/op.rs
+++ b/xrcf/src/dialect/func/op.rs
@@ -19,6 +19,7 @@ use crate::parser::Parse;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
+use crate::shared::Shared;
 use crate::shared::SharedExt;
 use anyhow::Result;
 use std::fmt::Formatter;

--- a/xrcf/src/dialect/func/op.rs
+++ b/xrcf/src/dialect/func/op.rs
@@ -264,8 +264,7 @@ impl FuncOp {
             block.set_ops(ops);
             operation.set_region(Some(region));
         } else {
-            let last = ops.last().unwrap();
-            last.insert_after(op.clone());
+            ops.last().unwrap().insert_after(op.clone());
         }
         UnsetOp::new(op.clone())
     }
@@ -300,14 +299,12 @@ impl FuncOp {
         f: &mut Formatter<'_>,
         indent: i32,
     ) -> std::fmt::Result {
-        let name = op.operation().rd().name();
-        write!(f, "{name} ")?;
+        write!(f, "{} ", op.operation().rd().name())?;
         if let Some(visibility) = FuncOp::display_visibility(op) {
             write!(f, "{visibility} ")?;
         }
         write!(f, "{identifier}(")?;
-        let arguments = op.operation().arguments();
-        write!(f, "{}", arguments)?;
+        write!(f, "{}", op.operation().arguments())?;
         write!(f, ")")?;
         let operation = op.operation();
         let result_types = operation.results().types();
@@ -318,8 +315,7 @@ impl FuncOp {
         if !attributes.is_empty() {
             write!(f, " attributes {attributes}")?;
         }
-        let region = op.operation().region();
-        if let Some(region) = region {
+        if let Some(region) = op.operation().region() {
             region.display(f, indent)?;
         }
         Ok(())
@@ -330,8 +326,7 @@ impl FuncOp {
     ) -> Option<String> {
         if expected_name == &FuncOp::operation_name() {
             if parser.check(TokenKind::BareIdentifier) {
-                let token = parser.advance();
-                let sym_visibility = token.lexeme.clone();
+                let sym_visibility = parser.advance().lexeme.clone();
                 return Some(sym_visibility);
             }
         }
@@ -411,12 +406,9 @@ impl<T: ParserDispatch> Parser<T> {
             op_rd.operation().set_region(Some(region.clone()));
             region.set_parent(Some(op.clone()));
 
-            {
-                let blocks = region.blocks();
-                let block = blocks.into_iter().next().unwrap();
-                for argument in arguments.into_iter() {
-                    argument.set_parent(Some(block.clone()));
-                }
+            let block = region.blocks().into_iter().next().unwrap();
+            for argument in arguments.into_iter() {
+                argument.set_parent(Some(block.clone()));
             }
         }
 
@@ -443,14 +435,12 @@ impl ReturnOp {
         let operation = op.operation();
         let name = operation.name();
         write!(f, "{name}")?;
-        let operands = operation.operands().vec();
-        let operands = operands.rd();
-        if !operands.is_empty() {
-            for operand in operands.iter() {
+        let operands = operation.operands().into_iter();
+        if operands.len() != 0 {
+            for operand in operands {
                 write!(f, " {}", operand.rd())?;
             }
-            let result_types = operation.results().types();
-            write!(f, " : {}", result_types)?;
+            write!(f, " : {}", operation.results().types())?;
         }
         Ok(())
     }

--- a/xrcf/src/dialect/llvm/attribute.rs
+++ b/xrcf/src/dialect/llvm/attribute.rs
@@ -3,10 +3,12 @@ use crate::ir::StringType;
 use crate::ir::Type;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
+use crate::shared::Shared;
 use std::fmt::Formatter;
 use std::fmt::Result;
 use std::sync::Arc;
 use std::sync::RwLock;
+
 pub struct LinkageAttr {
     value: String,
 }

--- a/xrcf/src/dialect/llvm/attribute.rs
+++ b/xrcf/src/dialect/llvm/attribute.rs
@@ -18,7 +18,7 @@ impl Attribute for LinkageAttr {
         }
     }
     fn typ(&self) -> Arc<RwLock<dyn Type>> {
-        Arc::new(RwLock::new(StringType::new()))
+        Shared::new(StringType::new().into())
     }
     fn parse<T: ParserDispatch>(parser: &mut Parser<T>) -> Option<Self> {
         let next = parser.peek();

--- a/xrcf/src/dialect/llvm/op.rs
+++ b/xrcf/src/dialect/llvm/op.rs
@@ -19,7 +19,7 @@ use crate::parser::Parse;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
-use crate::shared::RwLockExt;
+use crate::shared::SharedExt;
 use anyhow::Result;
 use std::fmt::Display;
 use std::fmt::Formatter;

--- a/xrcf/src/dialect/llvm/op.rs
+++ b/xrcf/src/dialect/llvm/op.rs
@@ -48,7 +48,7 @@ impl Op for AddOp {
         &self.operation
     }
     fn display(&self, f: &mut Formatter<'_>, _indent: i32) -> std::fmt::Result {
-        write!(f, "{}", self.operation().re())
+        write!(f, "{}", self.operation().rd())
     }
 }
 
@@ -101,21 +101,21 @@ impl Op for AllocaOp {
         &self.operation
     }
     fn display(&self, f: &mut Formatter<'_>, _indent: i32) -> std::fmt::Result {
-        let operation = self.operation().re();
+        let operation = self.operation().rd();
         write!(f, "{} = ", operation.results())?;
         write!(f, "{} ", operation.name())?;
         let array_size = self.array_size();
-        let array_size = array_size.re();
+        let array_size = array_size.rd();
         write!(f, "{}", array_size)?;
         write!(f, " x ")?;
         write!(f, "{}", self.element_type().expect("no element type"))?;
         write!(f, " : ")?;
         let array_size_type = array_size.typ().unwrap();
-        let array_size_type = array_size_type.re();
+        let array_size_type = array_size_type.rd();
         write!(f, "({})", array_size_type)?;
         write!(f, " -> ")?;
         let result_type = operation.result_type(0).unwrap();
-        let result_type = result_type.re();
+        let result_type = result_type.rd();
         write!(f, "{result_type}")?;
         Ok(())
     }
@@ -136,7 +136,7 @@ impl Parse for AllocaOp {
             parser.parse_op_operand_into(parent.unwrap(), TOKEN_KIND, &mut operation)?;
         parser.parse_keyword("x")?;
         let element_type = T::parse_type(parser)?;
-        let element_type = element_type.re();
+        let element_type = element_type.rd();
         parser.expect(TokenKind::Colon)?;
         parser.expect(TokenKind::LParen)?;
 
@@ -192,16 +192,16 @@ impl Op for BranchOp {
         write!(f, "{} ", self.operation.name())?;
         let dest = self.dest();
         let dest = dest.unwrap();
-        let dest = dest.re();
+        let dest = dest.rd();
         write!(f, "{}", dest)?;
         let operands = self.operation().operands();
         let operands = operands.vec();
-        let operands = operands.re();
+        let operands = operands.rd();
         let operands = operands.iter().skip(1);
         if 0 < operands.len() {
             write!(f, "(")?;
             for operand in operands {
-                let operand = operand.re();
+                let operand = operand.rd();
                 operand.display_with_type(f)?;
             }
             write!(f, ")")?;
@@ -390,9 +390,9 @@ impl Op for ConstantOp {
     fn display(&self, f: &mut Formatter<'_>, _indent: i32) -> std::fmt::Result {
         let results = self.operation().results();
         let results = results.vec();
-        let results = results.re();
+        let results = results.rd();
         let result = results.get(0).expect("no result");
-        let result = result.re();
+        let result = result.rd();
         write!(f, "{} = {}", result, Self::operation_name())?;
         write!(f, "(")?;
         let value = self.value();
@@ -400,7 +400,7 @@ impl Op for ConstantOp {
         write!(f, ")")?;
 
         let typ = self.operation().result_type(0).expect("no result type");
-        let typ = typ.re();
+        let typ = typ.rd();
         write!(f, " : {typ}")?;
 
         Ok(())
@@ -470,7 +470,7 @@ impl Op for GlobalOp {
     fn display(&self, f: &mut Formatter<'_>, _indent: i32) -> std::fmt::Result {
         write!(f, "{} ", Self::operation_name().name())?;
         let attributes = self.operation().attributes().map();
-        let attributes = attributes.re();
+        let attributes = attributes.rd();
         if let Some(attribute) = attributes.get("linkage") {
             write!(f, "{} ", attribute)?;
         }
@@ -545,7 +545,7 @@ impl Parse for FuncOp {
             if text == "attributes" {
                 parser.advance();
                 let attributes = parser.parse_attributes()?;
-                let op = op.re();
+                let op = op.rd();
                 op.operation().set_attributes(attributes);
             }
         }
@@ -649,12 +649,12 @@ impl StoreOp {
         self.operation().set_operand(0, value);
     }
     pub fn addr(&self) -> Arc<RwLock<OpOperand>> {
-        let operation = self.operation.re();
+        let operation = self.operation.rd();
         let operand = operation.operand(1).expect("no address set");
         operand
     }
     pub fn set_addr(&mut self, addr: Arc<RwLock<OpOperand>>) {
-        let operation = self.operation.re();
+        let operation = self.operation.rd();
         let mut operands = operation.operands();
         operands.set_operand(1, addr);
     }
@@ -674,15 +674,15 @@ impl Op for StoreOp {
         &self.operation
     }
     fn display(&self, f: &mut Formatter<'_>, _indent: i32) -> std::fmt::Result {
-        let operation = self.operation().re();
+        let operation = self.operation().rd();
         write!(f, "{}", operation.name())?;
         write!(f, " {}", operation.operands())?;
         write!(f, " : ")?;
         let value = self.value();
-        write!(f, "{}", value.typ().unwrap().re())?;
+        write!(f, "{}", value.typ().unwrap().rd())?;
         write!(f, ", ")?;
         let addr = self.addr();
-        write!(f, "{}", addr.typ().unwrap().re())?;
+        write!(f, "{}", addr.typ().unwrap().rd())?;
         Ok(())
     }
 }

--- a/xrcf/src/dialect/llvm/op.rs
+++ b/xrcf/src/dialect/llvm/op.rs
@@ -47,7 +47,7 @@ impl Op for AddOp {
         &self.operation
     }
     fn display(&self, f: &mut Formatter<'_>, _indent: i32) -> std::fmt::Result {
-        write!(f, "{}", self.operation().read().unwrap())
+        write!(f, "{}", self.operation().re())
     }
 }
 
@@ -100,7 +100,7 @@ impl Op for AllocaOp {
         &self.operation
     }
     fn display(&self, f: &mut Formatter<'_>, _indent: i32) -> std::fmt::Result {
-        let operation = self.operation().read().unwrap();
+        let operation = self.operation().re();
         write!(f, "{} = ", operation.results())?;
         write!(f, "{} ", operation.name())?;
         let array_size = self.array_size();
@@ -469,7 +469,7 @@ impl Op for GlobalOp {
     fn display(&self, f: &mut Formatter<'_>, _indent: i32) -> std::fmt::Result {
         write!(f, "{} ", Self::operation_name().name())?;
         let attributes = self.operation().attributes().map();
-        let attributes = attributes.read().unwrap();
+        let attributes = attributes.re();
         if let Some(attribute) = attributes.get("linkage") {
             write!(f, "{} ", attribute)?;
         }
@@ -673,7 +673,7 @@ impl Op for StoreOp {
         &self.operation
     }
     fn display(&self, f: &mut Formatter<'_>, _indent: i32) -> std::fmt::Result {
-        let operation = self.operation().read().unwrap();
+        let operation = self.operation().re();
         write!(f, "{}", operation.name())?;
         write!(f, " {}", operation.operands())?;
         write!(f, " : ")?;

--- a/xrcf/src/dialect/llvm/op.rs
+++ b/xrcf/src/dialect/llvm/op.rs
@@ -19,6 +19,7 @@ use crate::parser::Parse;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
+use crate::shared::Shared;
 use crate::shared::SharedExt;
 use anyhow::Result;
 use std::fmt::Display;

--- a/xrcf/src/dialect/llvm/op.rs
+++ b/xrcf/src/dialect/llvm/op.rs
@@ -148,10 +148,10 @@ impl Parse for AllocaOp {
         operation.set_result_type(0, result_type)?;
 
         let op = AllocaOp {
-            operation: Arc::new(RwLock::new(operation)),
+            operation: Shared::new(operation.into()),
             element_type: Some(element_type.to_string()),
         };
-        let op = Arc::new(RwLock::new(op));
+        let op = Shared::new(op.into());
         results.set_defining_op(op.clone());
         Ok(op)
     }
@@ -218,9 +218,9 @@ impl Parse for BranchOp {
         operation.set_parent(parent.clone());
         parser.parse_operation_name_into::<BranchOp>(&mut operation)?;
 
-        let operation = Arc::new(RwLock::new(operation));
+        let operation = Shared::new(operation.into());
         let dest = parser.parse_block_dest()?;
-        let dest = Arc::new(RwLock::new(dest));
+        let dest = Shared::new(dest.into());
         operation.set_operand(0, dest);
         if parser.check(TokenKind::LParen) {
             parser.expect(TokenKind::LParen)?;
@@ -238,7 +238,7 @@ impl Parse for BranchOp {
             parser.expect(TokenKind::RParen)?;
         }
         let op = BranchOp { operation };
-        let op = Arc::new(RwLock::new(op));
+        let op = Shared::new(op.into());
         Ok(op)
     }
 }
@@ -347,9 +347,9 @@ impl Parse for CondBranchOp {
         parser.parse_operation_name_into::<CondBranchOp>(&mut operation)?;
         parser.parse_op_operands_into(parent.clone().unwrap(), TOKEN_KIND, &mut operation)?;
 
-        let operation = Arc::new(RwLock::new(operation));
+        let operation = Shared::new(operation.into());
         let op = CondBranchOp { operation };
-        let op = Arc::new(RwLock::new(op));
+        let op = Shared::new(op.into());
         Ok(op)
     }
 }
@@ -439,11 +439,11 @@ impl Parse for ConstantOp {
         let typ = T::parse_type(parser)?;
         operation.set_result_type(0, typ)?;
 
-        let operation = Arc::new(RwLock::new(operation));
+        let operation = Shared::new(operation.into());
         let op = ConstantOp {
             operation: operation.clone(),
         };
-        let op = Arc::new(RwLock::new(op));
+        let op = Shared::new(op.into());
         results.set_defining_op(op.clone());
 
         Ok(op)
@@ -597,7 +597,7 @@ impl Parse for GlobalOp {
         operation.set_attributes(attributes);
         operation.set_parent(parent);
         let op = GlobalOp::from_operation(operation);
-        Ok(Arc::new(RwLock::new(op)))
+        Ok(Shared::new(op.into()))
     }
 }
 
@@ -713,9 +713,9 @@ impl Parse for StoreOp {
         parser.verify_type(addr, addr_type)?;
 
         let op = StoreOp {
-            operation: Arc::new(RwLock::new(operation)),
+            operation: Shared::new(operation.into()),
         };
-        Ok(Arc::new(RwLock::new(op)))
+        Ok(Shared::new(op.into()))
     }
 }
 

--- a/xrcf/src/dialect/llvm/op.rs
+++ b/xrcf/src/dialect/llvm/op.rs
@@ -19,6 +19,7 @@ use crate::parser::Parse;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
+use crate::shared::RwLockExt;
 use anyhow::Result;
 use std::fmt::Display;
 use std::fmt::Formatter;
@@ -224,7 +225,7 @@ impl Parse for BranchOp {
         if parser.check(TokenKind::LParen) {
             parser.expect(TokenKind::LParen)?;
             let operands = operation.operands().vec();
-            let mut operands = operands.try_write().unwrap();
+            let mut operands = operands.wr();
             loop {
                 let operand = parser.parse_op_operand(parent.clone().unwrap(), TOKEN_KIND)?;
                 operands.push(operand);

--- a/xrcf/src/dialect/llvm/op.rs
+++ b/xrcf/src/dialect/llvm/op.rs
@@ -104,17 +104,17 @@ impl Op for AllocaOp {
         write!(f, "{} = ", operation.results())?;
         write!(f, "{} ", operation.name())?;
         let array_size = self.array_size();
-        let array_size = array_size.try_read().unwrap();
+        let array_size = array_size.re();
         write!(f, "{}", array_size)?;
         write!(f, " x ")?;
         write!(f, "{}", self.element_type().expect("no element type"))?;
         write!(f, " : ")?;
         let array_size_type = array_size.typ().unwrap();
-        let array_size_type = array_size_type.try_read().unwrap();
+        let array_size_type = array_size_type.re();
         write!(f, "({})", array_size_type)?;
         write!(f, " -> ")?;
         let result_type = operation.result_type(0).unwrap();
-        let result_type = result_type.try_read().unwrap();
+        let result_type = result_type.re();
         write!(f, "{result_type}")?;
         Ok(())
     }
@@ -135,7 +135,7 @@ impl Parse for AllocaOp {
             parser.parse_op_operand_into(parent.unwrap(), TOKEN_KIND, &mut operation)?;
         parser.parse_keyword("x")?;
         let element_type = T::parse_type(parser)?;
-        let element_type = element_type.try_read().unwrap();
+        let element_type = element_type.re();
         parser.expect(TokenKind::Colon)?;
         parser.expect(TokenKind::LParen)?;
 
@@ -191,16 +191,16 @@ impl Op for BranchOp {
         write!(f, "{} ", self.operation.name())?;
         let dest = self.dest();
         let dest = dest.unwrap();
-        let dest = dest.try_read().unwrap();
+        let dest = dest.re();
         write!(f, "{}", dest)?;
         let operands = self.operation().operands();
         let operands = operands.vec();
-        let operands = operands.try_read().unwrap();
+        let operands = operands.re();
         let operands = operands.iter().skip(1);
         if 0 < operands.len() {
             write!(f, "(")?;
             for operand in operands {
-                let operand = operand.try_read().unwrap();
+                let operand = operand.re();
                 operand.display_with_type(f)?;
             }
             write!(f, ")")?;
@@ -389,9 +389,9 @@ impl Op for ConstantOp {
     fn display(&self, f: &mut Formatter<'_>, _indent: i32) -> std::fmt::Result {
         let results = self.operation().results();
         let results = results.vec();
-        let results = results.try_read().unwrap();
+        let results = results.re();
         let result = results.get(0).expect("no result");
-        let result = result.try_read().unwrap();
+        let result = result.re();
         write!(f, "{} = {}", result, Self::operation_name())?;
         write!(f, "(")?;
         let value = self.value();
@@ -399,7 +399,7 @@ impl Op for ConstantOp {
         write!(f, ")")?;
 
         let typ = self.operation().result_type(0).expect("no result type");
-        let typ = typ.try_read().unwrap();
+        let typ = typ.re();
         write!(f, " : {typ}")?;
 
         Ok(())
@@ -544,7 +544,7 @@ impl Parse for FuncOp {
             if text == "attributes" {
                 parser.advance();
                 let attributes = parser.parse_attributes()?;
-                let op = op.try_read().unwrap();
+                let op = op.re();
                 op.operation().set_attributes(attributes);
             }
         }
@@ -648,12 +648,12 @@ impl StoreOp {
         self.operation().set_operand(0, value);
     }
     pub fn addr(&self) -> Arc<RwLock<OpOperand>> {
-        let operation = self.operation.try_read().unwrap();
+        let operation = self.operation.re();
         let operand = operation.operand(1).expect("no address set");
         operand
     }
     pub fn set_addr(&mut self, addr: Arc<RwLock<OpOperand>>) {
-        let operation = self.operation.try_read().unwrap();
+        let operation = self.operation.re();
         let mut operands = operation.operands();
         operands.set_operand(1, addr);
     }
@@ -678,10 +678,10 @@ impl Op for StoreOp {
         write!(f, " {}", operation.operands())?;
         write!(f, " : ")?;
         let value = self.value();
-        write!(f, "{}", value.typ().unwrap().try_read().unwrap())?;
+        write!(f, "{}", value.typ().unwrap().re())?;
         write!(f, ", ")?;
         let addr = self.addr();
-        write!(f, "{}", addr.typ().unwrap().try_read().unwrap())?;
+        write!(f, "{}", addr.typ().unwrap().re())?;
         Ok(())
     }
 }

--- a/xrcf/src/dialect/llvm/typ.rs
+++ b/xrcf/src/dialect/llvm/typ.rs
@@ -68,7 +68,7 @@ impl ArrayType {
 
 impl Type for ArrayType {
     fn display(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let element_type = self.element_type.re();
+        let element_type = self.element_type.rd();
         write!(f, "!llvm.array<{} x {}>", self.num_elements, element_type)
     }
     fn as_any(&self) -> &dyn std::any::Any {

--- a/xrcf/src/dialect/llvm/typ.rs
+++ b/xrcf/src/dialect/llvm/typ.rs
@@ -4,6 +4,7 @@ use crate::ir::Type;
 use crate::ir::TypeParse;
 use crate::ir::Types;
 use crate::shared::Shared;
+use crate::shared::SharedExt;
 use anyhow::Result;
 use std::fmt::Display;
 use std::fmt::Formatter;

--- a/xrcf/src/dialect/llvm/typ.rs
+++ b/xrcf/src/dialect/llvm/typ.rs
@@ -3,6 +3,7 @@ use crate::ir::IntegerType;
 use crate::ir::Type;
 use crate::ir::TypeParse;
 use crate::ir::Types;
+use crate::shared::SharedExt;
 use anyhow::Result;
 use std::fmt::Display;
 use std::fmt::Formatter;
@@ -66,7 +67,7 @@ impl ArrayType {
 
 impl Type for ArrayType {
     fn display(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let element_type = self.element_type.read().unwrap();
+        let element_type = self.element_type.re();
         write!(f, "!llvm.array<{} x {}>", self.num_elements, element_type)
     }
     fn as_any(&self) -> &dyn std::any::Any {

--- a/xrcf/src/dialect/llvm/typ.rs
+++ b/xrcf/src/dialect/llvm/typ.rs
@@ -68,8 +68,12 @@ impl ArrayType {
 
 impl Type for ArrayType {
     fn display(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let element_type = self.element_type.rd();
-        write!(f, "!llvm.array<{} x {}>", self.num_elements, element_type)
+        write!(
+            f,
+            "!llvm.array<{} x {}>",
+            self.num_elements,
+            self.element_type.rd()
+        )
     }
     fn as_any(&self) -> &dyn std::any::Any {
         self

--- a/xrcf/src/dialect/llvm/typ.rs
+++ b/xrcf/src/dialect/llvm/typ.rs
@@ -3,7 +3,7 @@ use crate::ir::IntegerType;
 use crate::ir::Type;
 use crate::ir::TypeParse;
 use crate::ir::Types;
-use crate::shared::SharedExt;
+use crate::shared::Shared;
 use anyhow::Result;
 use std::fmt::Display;
 use std::fmt::Formatter;
@@ -33,7 +33,7 @@ impl ArrayType {
         let (num_elements, element_type) = s.split_once('x').unwrap();
         let num_elements = num_elements.parse::<u32>().unwrap();
         let element_type = IntegerType::from_str(element_type);
-        let element_type = Arc::new(RwLock::new(element_type));
+        let element_type = Shared::new(element_type.into());
         Self {
             num_elements,
             element_type,
@@ -45,7 +45,7 @@ impl ArrayType {
         let text = text.trim_matches('"');
         let num_elements = text.as_bytes().len() as u32;
         let element_type = IntegerType::from_str("i8");
-        let element_type = Arc::new(RwLock::new(element_type));
+        let element_type = Shared::new(element_type.into());
         Self {
             num_elements,
             element_type,
@@ -54,7 +54,7 @@ impl ArrayType {
     pub fn for_bytes(bytes: &Vec<u8>) -> Self {
         let num_elements = bytes.len() as u32;
         let element_type = IntegerType::from_str("i8");
-        let element_type = Arc::new(RwLock::new(element_type));
+        let element_type = Shared::new(element_type.into());
         Self {
             num_elements,
             element_type,
@@ -107,7 +107,7 @@ impl FunctionType {
         let (return_types, arguments) = s.split_once('(').unwrap();
 
         let return_type = IntegerType::from_str(return_types.trim());
-        let return_type = Arc::new(RwLock::new(return_type));
+        let return_type = Shared::new(return_type.into());
         let return_types = Types::from_vec(vec![return_type]);
 
         let arguments_str = arguments.trim_end_matches(")>");
@@ -185,19 +185,19 @@ impl Type for VariadicType {
 impl TypeParse for LLVM {
     fn parse_type(src: &str) -> Result<Arc<RwLock<dyn Type>>> {
         if src.starts_with("!llvm.array") {
-            return Ok(Arc::new(RwLock::new(ArrayType::parse_str(src))));
+            return Ok(Shared::new(ArrayType::parse_str(src).into()));
         }
         if src.starts_with("!llvm.func") {
-            return Ok(Arc::new(RwLock::new(FunctionType::from_str(src))));
+            return Ok(Shared::new(FunctionType::from_str(src).into()));
         }
         if src.starts_with("!llvm.ptr") {
-            return Ok(Arc::new(RwLock::new(PointerType::from_str(src))));
+            return Ok(Shared::new(PointerType::from_str(src).into()));
         }
         if src.starts_with("ptr") {
-            return Ok(Arc::new(RwLock::new(PointerType::from_str(src))));
+            return Ok(Shared::new(PointerType::from_str(src).into()));
         }
         if src == "..." {
-            return Ok(Arc::new(RwLock::new(VariadicType::from_str(src))));
+            return Ok(Shared::new(VariadicType::from_str(src).into()));
         }
         todo!("Not yet implemented for {}", src)
     }

--- a/xrcf/src/dialect/scf/op.rs
+++ b/xrcf/src/dialect/scf/op.rs
@@ -119,13 +119,13 @@ impl Parse for IfOp {
             parser.expect(TokenKind::RParen)?;
         }
 
-        let operation = Arc::new(RwLock::new(operation));
+        let operation = Shared::new(operation);
         let op = IfOp {
             operation,
             then: None,
             els: None,
         };
-        let op = Arc::new(RwLock::new(op));
+        let op = Shared::new(op.into());
         let then = parser.parse_region(op.clone())?;
         let else_keyword = parser.expect(TokenKind::BareIdentifier)?;
         if else_keyword.lexeme() != "else" {
@@ -187,9 +187,9 @@ impl Parse for YieldOp {
         parser.expect(TokenKind::Colon)?;
         parser.parse_type_for_op_operand(operand)?;
 
-        let operation = Arc::new(RwLock::new(operation));
+        let operation = Shared::new(operation.into());
         let op = YieldOp { operation };
-        let op = Arc::new(RwLock::new(op));
+        let op = Shared::new(op.into());
         Ok(op)
     }
 }

--- a/xrcf/src/dialect/scf/op.rs
+++ b/xrcf/src/dialect/scf/op.rs
@@ -9,7 +9,7 @@ use crate::parser::Parse;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
-use crate::shared::RwLockExt;
+use crate::shared::SharedExt;
 use anyhow::Result;
 use std::fmt::Formatter;
 use std::sync::Arc;

--- a/xrcf/src/dialect/scf/op.rs
+++ b/xrcf/src/dialect/scf/op.rs
@@ -9,6 +9,7 @@ use crate::parser::Parse;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
+use crate::shared::RwLockExt;
 use anyhow::Result;
 use std::fmt::Formatter;
 use std::sync::Arc;
@@ -132,7 +133,7 @@ impl Parse for IfOp {
         }
         let els = parser.parse_region(op.clone())?;
         let op_write = op.clone();
-        let mut op_write = op_write.try_write().unwrap();
+        let mut op_write = op_write.wr();
         op_write.then = Some(then);
         op_write.els = Some(els);
         results.set_defining_op(op.clone());

--- a/xrcf/src/dialect/scf/op.rs
+++ b/xrcf/src/dialect/scf/op.rs
@@ -81,10 +81,10 @@ impl Op for IfOp {
             write!(f, " -> ({})", self.operation.results().types())?;
         }
         let then = self.then.clone().expect("Expected `then` region");
-        let then = then.try_read().unwrap();
+        let then = then.re();
         then.display(f, indent)?;
         let els = self.els.clone().expect("Expected `else` region");
-        let els = els.try_read().unwrap();
+        let els = els.re();
         write!(f, " else")?;
         els.display(f, indent)?;
         Ok(())

--- a/xrcf/src/dialect/scf/op.rs
+++ b/xrcf/src/dialect/scf/op.rs
@@ -81,13 +81,15 @@ impl Op for IfOp {
         if has_results {
             write!(f, " -> ({})", self.operation.results().types())?;
         }
-        let then = self.then.clone().expect("Expected `then` region");
-        let then = then.rd();
-        then.display(f, indent)?;
-        let els = self.els.clone().expect("Expected `else` region");
-        let els = els.rd();
+        self.then()
+            .expect("no `then` region")
+            .rd()
+            .display(f, indent)?;
         write!(f, " else")?;
-        els.display(f, indent)?;
+        self.els()
+            .expect("no `else` region")
+            .rd()
+            .display(f, indent)?;
         Ok(())
     }
 }

--- a/xrcf/src/dialect/scf/op.rs
+++ b/xrcf/src/dialect/scf/op.rs
@@ -9,6 +9,7 @@ use crate::parser::Parse;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
+use crate::shared::Shared;
 use crate::shared::SharedExt;
 use anyhow::Result;
 use std::fmt::Formatter;
@@ -119,7 +120,7 @@ impl Parse for IfOp {
             parser.expect(TokenKind::RParen)?;
         }
 
-        let operation = Shared::new(operation);
+        let operation = Shared::new(operation.into());
         let op = IfOp {
             operation,
             then: None,

--- a/xrcf/src/dialect/scf/op.rs
+++ b/xrcf/src/dialect/scf/op.rs
@@ -82,10 +82,10 @@ impl Op for IfOp {
             write!(f, " -> ({})", self.operation.results().types())?;
         }
         let then = self.then.clone().expect("Expected `then` region");
-        let then = then.re();
+        let then = then.rd();
         then.display(f, indent)?;
         let els = self.els.clone().expect("Expected `else` region");
-        let els = els.re();
+        let els = els.rd();
         write!(f, " else")?;
         els.display(f, indent)?;
         Ok(())

--- a/xrcf/src/ir/attribute.rs
+++ b/xrcf/src/ir/attribute.rs
@@ -9,6 +9,7 @@ use crate::ir::Type;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
+use crate::shared::SharedExt;
 use anyhow::Result;
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -236,7 +237,7 @@ impl Attributes {
         self.map.clone()
     }
     pub fn is_empty(&self) -> bool {
-        self.map.read().unwrap().is_empty()
+        self.map.re().is_empty()
     }
     pub fn insert(&self, name: &str, attribute: Arc<dyn Attribute>) {
         self.map
@@ -245,10 +246,10 @@ impl Attributes {
             .insert(name.to_string(), attribute);
     }
     pub fn get(&self, name: &str) -> Option<Arc<dyn Attribute>> {
-        self.map.read().unwrap().get(name).cloned()
+        self.map.re().get(name).cloned()
     }
     pub fn deep_clone(&self) -> Self {
-        let map = self.map.read().unwrap();
+        let map = self.map.re();
         let mut out = HashMap::new();
         for (name, attribute) in map.iter() {
             let attribute = attribute.clone();
@@ -261,7 +262,7 @@ impl Attributes {
 
 impl Display for Attributes {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let map = self.map.read().unwrap();
+        let map = self.map.re();
         if !map.is_empty() {
             write!(f, "{{")?;
             for (i, attr) in map.iter().enumerate() {

--- a/xrcf/src/ir/attribute.rs
+++ b/xrcf/src/ir/attribute.rs
@@ -250,11 +250,9 @@ impl Attributes {
         self.map.rd().get(name).cloned()
     }
     pub fn deep_clone(&self) -> Self {
-        let map = self.map.rd();
         let mut out = HashMap::new();
-        for (name, attribute) in map.iter() {
-            let attribute = attribute.clone();
-            out.insert(name.to_string(), attribute);
+        for (name, attribute) in self.map.rd().iter() {
+            out.insert(name.to_string(), attribute.clone());
         }
         let map = Shared::new(out.into());
         Self { map }
@@ -263,14 +261,14 @@ impl Attributes {
 
 impl Display for Attributes {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let map = self.map.rd();
-        if !map.is_empty() {
+        let map = self.map.rd().clone().into_iter();
+        if map.len() != 0 {
             write!(f, "{{")?;
-            for (i, attr) in map.iter().enumerate() {
-                let (name, attribute) = attr;
+            for (i, attr) in map.enumerate() {
                 if 0 < i {
                     write!(f, " ")?;
                 }
+                let (name, attribute) = attr;
                 write!(f, "{name} = {attribute}")?;
             }
             write!(f, "}}")?;

--- a/xrcf/src/ir/attribute.rs
+++ b/xrcf/src/ir/attribute.rs
@@ -63,7 +63,7 @@ impl Attribute for BooleanAttr {
         Self { value }
     }
     fn typ(&self) -> Arc<RwLock<dyn Type>> {
-        Arc::new(RwLock::new(IntegerType::from_str("i1")))
+        Shared::new(IntegerType::from_str("i1").into())
     }
     fn as_any(&self) -> &dyn std::any::Any {
         self
@@ -113,7 +113,7 @@ impl Attribute for IntegerAttr {
         }
     }
     fn typ(&self) -> Arc<RwLock<dyn Type>> {
-        Arc::new(RwLock::new(self.typ))
+        Shared::new(self.typ.into())
     }
     fn parse<T: ParserDispatch>(_parser: &mut Parser<T>) -> Option<Self> {
         todo!()
@@ -168,7 +168,7 @@ impl Attribute for StringAttr {
         Self { value }
     }
     fn typ(&self) -> Arc<RwLock<dyn Type>> {
-        Arc::new(RwLock::new(StringType::new()))
+        Shared::new(StringType::new().into())
     }
     fn parse<T: ParserDispatch>(_parser: &mut Parser<T>) -> Option<Self> {
         todo!()
@@ -203,7 +203,7 @@ impl Attribute for AnyAttr {
         }
     }
     fn typ(&self) -> Arc<RwLock<dyn Type>> {
-        Arc::new(RwLock::new(StringType::new()))
+        Shared::new(StringType::new())
     }
     fn parse<T: ParserDispatch>(parser: &mut Parser<T>) -> Option<Self> {
         let value = parser.advance();
@@ -230,7 +230,7 @@ pub struct Attributes {
 impl Attributes {
     pub fn new() -> Self {
         Self {
-            map: Arc::new(RwLock::new(HashMap::new())),
+            map: Shared::new(HashMap::new()),
         }
     }
     pub fn map(&self) -> Arc<RwLock<HashMap<String, Arc<dyn Attribute>>>> {
@@ -255,7 +255,7 @@ impl Attributes {
             let attribute = attribute.clone();
             out.insert(name.to_string(), attribute);
         }
-        let map = Arc::new(RwLock::new(out));
+        let map = Shared::new(out);
         Self { map }
     }
 }

--- a/xrcf/src/ir/attribute.rs
+++ b/xrcf/src/ir/attribute.rs
@@ -238,7 +238,7 @@ impl Attributes {
         self.map.clone()
     }
     pub fn is_empty(&self) -> bool {
-        self.map.re().is_empty()
+        self.map.rd().is_empty()
     }
     pub fn insert(&self, name: &str, attribute: Arc<dyn Attribute>) {
         self.map
@@ -247,10 +247,10 @@ impl Attributes {
             .insert(name.to_string(), attribute);
     }
     pub fn get(&self, name: &str) -> Option<Arc<dyn Attribute>> {
-        self.map.re().get(name).cloned()
+        self.map.rd().get(name).cloned()
     }
     pub fn deep_clone(&self) -> Self {
-        let map = self.map.re();
+        let map = self.map.rd();
         let mut out = HashMap::new();
         for (name, attribute) in map.iter() {
             let attribute = attribute.clone();
@@ -263,7 +263,7 @@ impl Attributes {
 
 impl Display for Attributes {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let map = self.map.re();
+        let map = self.map.rd();
         if !map.is_empty() {
             write!(f, "{{")?;
             for (i, attr) in map.iter().enumerate() {

--- a/xrcf/src/ir/attribute.rs
+++ b/xrcf/src/ir/attribute.rs
@@ -9,6 +9,7 @@ use crate::ir::Type;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
+use crate::shared::Shared;
 use crate::shared::SharedExt;
 use anyhow::Result;
 use std::collections::HashMap;
@@ -203,7 +204,7 @@ impl Attribute for AnyAttr {
         }
     }
     fn typ(&self) -> Arc<RwLock<dyn Type>> {
-        Shared::new(StringType::new())
+        Shared::new(StringType::new().into())
     }
     fn parse<T: ParserDispatch>(parser: &mut Parser<T>) -> Option<Self> {
         let value = parser.advance();
@@ -230,7 +231,7 @@ pub struct Attributes {
 impl Attributes {
     pub fn new() -> Self {
         Self {
-            map: Shared::new(HashMap::new()),
+            map: Shared::new(HashMap::new().into()),
         }
     }
     pub fn map(&self) -> Arc<RwLock<HashMap<String, Arc<dyn Attribute>>>> {
@@ -255,7 +256,7 @@ impl Attributes {
             let attribute = attribute.clone();
             out.insert(name.to_string(), attribute);
         }
-        let map = Shared::new(out);
+        let map = Shared::new(out.into());
         Self { map }
     }
 }

--- a/xrcf/src/ir/block.rs
+++ b/xrcf/src/ir/block.rs
@@ -378,9 +378,8 @@ impl Block {
     }
     /// Find a unique name for a value (for example, `%4 = ...`).
     pub fn unique_value_name(&self, prefix: &str) -> String {
-        let used_names = self.used_names_with_predecessors();
         let mut new_name: i32 = -1;
-        for name in used_names.iter() {
+        for name in self.used_names_with_predecessors().iter() {
             let name = name.trim_start_matches(prefix);
             if let Ok(num) = name.parse::<i32>() {
                 // Ensure new_name is greater than any used name.
@@ -392,25 +391,18 @@ impl Block {
         format!("{prefix}{new_name}")
     }
     pub fn display(&self, f: &mut Formatter<'_>, indent: i32) -> std::fmt::Result {
-        let label = self.label();
-        let label = label.rd();
-        if let BlockName::Name(name) = &*label {
+        if let BlockName::Name(name) = &*self.label.rd() {
             let label_indent = if indent > 0 { indent - 1 } else { 0 };
-            let spaces = crate::ir::spaces(label_indent);
-            write!(f, "{spaces}{name}")?;
+            write!(f, "{}{name}", crate::ir::spaces(label_indent))?;
             let arguments = self.arguments();
             if !arguments.is_empty() {
                 write!(f, "({arguments})")?;
             }
             write!(f, ":\n")?;
         }
-        let ops = self.ops();
-        let ops = ops.rd();
-        for op in ops.iter() {
-            let spaces = crate::ir::spaces(indent);
-            write!(f, "{spaces}")?;
-            let op = op.rd();
-            op.display(f, indent)?;
+        for op in self.ops().rd().iter() {
+            write!(f, "{}", crate::ir::spaces(indent))?;
+            op.rd().display(f, indent)?;
             write!(f, "\n")?;
         }
         Ok(())
@@ -446,8 +438,7 @@ impl UnsetBlock {
         self.block.clone()
     }
     pub fn set_parent(&self, parent: Option<Arc<RwLock<Region>>>) -> Arc<RwLock<Block>> {
-        let mut block = self.block.wr();
-        block.set_parent(parent);
+        self.block.wr().set_parent(parent);
         self.block.clone()
     }
 }

--- a/xrcf/src/ir/block.rs
+++ b/xrcf/src/ir/block.rs
@@ -358,26 +358,20 @@ impl Block {
     fn set_arguments(&mut self, arguments: Values) {
         self.arguments = arguments;
     }
-    pub fn used_names_without_predecessors(&self) -> Vec<String> {
+    pub fn used_names(&self) -> Vec<String> {
         let ops = self.ops();
         let ops = ops.rd();
         let mut used_names = vec![];
         for op in ops.iter() {
-            let op = op.rd();
-            let operation = op.operation();
-            let operation = operation.rd();
-            let result_names = operation.result_names();
-            used_names.extend(result_names);
+            used_names.extend(op.rd().operation().rd().result_names());
         }
         used_names
     }
     fn used_names_with_predecessors(&self) -> Vec<String> {
-        let predecessors = self.predecessors();
-        let mut used_names = self.used_names_without_predecessors();
-        if let Some(predecessors) = predecessors {
-            for predecessor in predecessors.iter() {
-                let predecessor = predecessor.rd();
-                used_names.extend(Self::used_names_without_predecessors(&predecessor));
+        let mut used_names = self.used_names();
+        if let Some(predecessors) = self.predecessors() {
+            for p in predecessors.iter() {
+                used_names.extend(p.rd().used_names());
             }
         }
         used_names

--- a/xrcf/src/ir/block.rs
+++ b/xrcf/src/ir/block.rs
@@ -8,6 +8,7 @@ use crate::ir::Operation;
 use crate::ir::Region;
 use crate::ir::Value;
 use crate::ir::Values;
+use crate::shared::Shared;
 use crate::shared::SharedExt;
 use std::fmt::Display;
 use std::fmt::Formatter;
@@ -479,7 +480,7 @@ impl Default for Block {
     fn default() -> Self {
         let label = Shared::new(BlockName::Unnamed.into());
         let arguments = Values::default();
-        let ops = Shared::new(vec![]);
+        let ops = Shared::new(vec![].into());
         let parent = None;
         Self::new(label, arguments, ops, parent)
     }

--- a/xrcf/src/ir/block.rs
+++ b/xrcf/src/ir/block.rs
@@ -200,7 +200,7 @@ impl Block {
         if op.is_func() {
             for argument in operation.rd().arguments().into_iter() {
                 match &*argument.rd() {
-                    Value::BlockArgument(block_argument) => match &*block_argument.name().rd() {
+                    Value::BlockArgument(arg) => match &*arg.name().rd() {
                         BlockArgumentName::Name(curr) => {
                             if curr == name {
                                 return Some(argument.clone());

--- a/xrcf/src/ir/block.rs
+++ b/xrcf/src/ir/block.rs
@@ -197,22 +197,17 @@ impl Block {
         let op = parent.unwrap();
         let op = &*op.rd();
         let operation = op.operation();
-        let operation = operation.rd();
         if op.is_func() {
-            let arguments = operation.arguments();
-            let arguments = arguments.vec();
-            let arguments = arguments.rd();
-            for argument in arguments.iter() {
+            for argument in operation.rd().arguments().into_iter() {
                 match &*argument.rd() {
-                    Value::BlockArgument(block_argument) => {
-                        let current_name = block_argument.name();
-                        let current_name = current_name.rd();
-                        if let BlockArgumentName::Name(current_name) = &*current_name {
-                            if current_name == name {
+                    Value::BlockArgument(block_argument) => match &*block_argument.name().rd() {
+                        BlockArgumentName::Name(curr) => {
+                            if curr == name {
                                 return Some(argument.clone());
                             }
                         }
-                    }
+                        _ => {}
+                    },
                     _ => panic!("Expected BlockArgument"),
                 }
             }

--- a/xrcf/src/ir/block.rs
+++ b/xrcf/src/ir/block.rs
@@ -477,9 +477,9 @@ impl Block {
 
 impl Default for Block {
     fn default() -> Self {
-        let label = Arc::new(RwLock::new(BlockName::Unnamed));
+        let label = Shared::new(BlockName::Unnamed.into());
         let arguments = Values::default();
-        let ops = Arc::new(RwLock::new(vec![]));
+        let ops = Shared::new(vec![]);
         let parent = None;
         Self::new(label, arguments, ops, parent)
     }

--- a/xrcf/src/ir/block.rs
+++ b/xrcf/src/ir/block.rs
@@ -203,7 +203,7 @@ impl Block {
             "Found no parent for region {region} when searching for assignment of {name}"
         );
         let op = parent.unwrap();
-        let op = &*op.try_read().unwrap();
+        let op = &*op.re();
         let operation = op.operation();
         let operation = operation.try_read().unwrap();
         if op.is_func() {

--- a/xrcf/src/ir/block.rs
+++ b/xrcf/src/ir/block.rs
@@ -8,7 +8,7 @@ use crate::ir::Operation;
 use crate::ir::Region;
 use crate::ir::Value;
 use crate::ir::Values;
-use crate::shared::RwLockExt;
+use crate::shared::SharedExt;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::sync::Arc;

--- a/xrcf/src/ir/block.rs
+++ b/xrcf/src/ir/block.rs
@@ -355,15 +355,11 @@ impl Block {
     /// The caller is in charge of transferring the control flow to the region
     /// and pass it the correct block arguments.
     pub fn inline_region_before(&self, region: Arc<RwLock<Region>>) {
-        let parent = self.parent();
-        let parent = parent.expect("no parent");
-        let blocks = parent.blocks();
-        blocks.splice(self, region.blocks());
+        let parent = self.parent().expect("no parent");
+        parent.blocks().splice(self, region.blocks());
     }
     pub fn insert_op(&self, op: Arc<RwLock<dyn Op>>, index: usize) {
-        let ops = self.ops();
-        let mut ops = ops.try_write().unwrap();
-        ops.insert(index, op);
+        self.ops.try_write().unwrap().insert(index, op);
     }
     pub fn insert_after(&self, earlier: Arc<RwLock<Operation>>, later: Arc<RwLock<dyn Op>>) {
         let index = self.index_of_arc(earlier.clone());

--- a/xrcf/src/ir/block.rs
+++ b/xrcf/src/ir/block.rs
@@ -196,7 +196,7 @@ impl Block {
         let region = self.parent();
         assert!(region.is_some());
         let region = region.unwrap();
-        let region = region.read().unwrap();
+        let region = region.re();
         let parent = region.parent();
         assert!(
             parent.is_some(),

--- a/xrcf/src/ir/block.rs
+++ b/xrcf/src/ir/block.rs
@@ -220,16 +220,8 @@ impl Block {
         None
     }
     pub fn assignment_in_ops(&self, name: &str) -> Option<Arc<RwLock<Value>>> {
-        let ops = self.ops();
-        let ops = ops.rd();
-        for op in ops.iter() {
-            let op = op.rd();
-            let values = op.assignments();
-            assert!(values.is_ok());
-            let values = values.unwrap();
-            let values = values.vec();
-            let values = values.rd();
-            for value in values.iter() {
+        for op in self.ops().rd().iter() {
+            for value in op.rd().assignments().unwrap().into_iter() {
                 match &*value.rd() {
                     Value::BlockArgument(_block_argument) => {
                         // Ignore this case because we are looking for
@@ -241,10 +233,8 @@ impl Block {
                     Value::Constant(_) => continue,
                     Value::FuncResult(_) => return None,
                     Value::OpResult(op_result) => {
-                        let current_name = op_result.name();
-                        let current_name = current_name.rd();
-                        if let Some(current_name) = &*current_name {
-                            if current_name == name {
+                        if let Some(curr) = &*op_result.name().rd() {
+                            if curr == name {
                                 return Some(value.clone());
                             }
                         }

--- a/xrcf/src/ir/module.rs
+++ b/xrcf/src/ir/module.rs
@@ -36,7 +36,7 @@ impl Op for ModuleOp {
         &self.operation
     }
     fn display(&self, f: &mut Formatter<'_>, indent: i32) -> std::fmt::Result {
-        let operation = self.operation().re();
+        let operation = self.operation().rd();
         let spaces = crate::ir::spaces(indent);
         write!(f, "{spaces}")?;
         operation.display(f, indent)
@@ -45,13 +45,13 @@ impl Op for ModuleOp {
 
 impl Display for ModuleOp {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.operation().re())
+        write!(f, "{}", self.operation().rd())
     }
 }
 
 impl ModuleOp {
     pub fn get_body_region(&self) -> Result<Option<Arc<RwLock<Region>>>> {
-        Ok(self.operation().re().region())
+        Ok(self.operation().rd().region())
     }
     pub fn first_op(&self) -> Result<Arc<RwLock<dyn Op>>> {
         let body_region = self.get_body_region()?;
@@ -64,8 +64,8 @@ impl ModuleOp {
             Some(block) => block,
             None => return Err(anyhow::anyhow!("Expected 1 block in module, got 0")),
         };
-        let ops = block.re().ops();
-        let ops = ops.re();
+        let ops = block.rd().ops();
+        let ops = ops.rd();
         let op = ops.first();
         if op.is_none() {
             return Err(anyhow::anyhow!("Expected 1 op, got 0"));

--- a/xrcf/src/ir/module.rs
+++ b/xrcf/src/ir/module.rs
@@ -60,13 +60,10 @@ impl ModuleOp {
             Some(block) => block,
             None => return Err(anyhow::anyhow!("Expected 1 block in module, got 0")),
         };
-        let x = match block.rd().ops().rd().first() {
-            None => {
-                return Err(anyhow::anyhow!("Expected 1 op, got 0"));
-            }
-            Some(op) => Ok(op.clone()),
+        match block.rd().ops().rd().first() {
+            None => return Err(anyhow::anyhow!("Expected 1 op, got 0")),
+            Some(op) => return Ok(op.clone()),
         };
-        x
     }
 }
 

--- a/xrcf/src/ir/module.rs
+++ b/xrcf/src/ir/module.rs
@@ -84,11 +84,11 @@ impl Parse for ModuleOp {
         let operation_name = parser.expect(TokenKind::BareIdentifier)?;
         assert!(operation_name.lexeme == "module");
         operation.set_name(ModuleOp::operation_name());
-        let operation = Arc::new(RwLock::new(operation));
+        let operation = Shared::new(operation.into());
         let op = ModuleOp {
             operation: operation.clone(),
         };
-        let op = Arc::new(RwLock::new(op));
+        let op = Shared::new(op.into());
 
         let region = parser.parse_region(op.clone());
         let mut operation = operation.wr();

--- a/xrcf/src/ir/module.rs
+++ b/xrcf/src/ir/module.rs
@@ -8,6 +8,7 @@ use crate::parser::Parse;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
+use crate::shared::Shared;
 use crate::shared::SharedExt;
 use anyhow::Result;
 use std::fmt::Display;

--- a/xrcf/src/ir/module.rs
+++ b/xrcf/src/ir/module.rs
@@ -35,7 +35,7 @@ impl Op for ModuleOp {
         &self.operation
     }
     fn display(&self, f: &mut Formatter<'_>, indent: i32) -> std::fmt::Result {
-        let operation = self.operation().read().unwrap();
+        let operation = self.operation().re();
         let spaces = crate::ir::spaces(indent);
         write!(f, "{spaces}")?;
         operation.display(f, indent)
@@ -44,13 +44,13 @@ impl Op for ModuleOp {
 
 impl Display for ModuleOp {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.operation().read().unwrap())
+        write!(f, "{}", self.operation().re())
     }
 }
 
 impl ModuleOp {
     pub fn get_body_region(&self) -> Result<Option<Arc<RwLock<Region>>>> {
-        Ok(self.operation().read().unwrap().region())
+        Ok(self.operation().re().region())
     }
     pub fn first_op(&self) -> Result<Arc<RwLock<dyn Op>>> {
         let body_region = self.get_body_region()?;
@@ -63,8 +63,8 @@ impl ModuleOp {
             Some(block) => block,
             None => return Err(anyhow::anyhow!("Expected 1 block in module, got 0")),
         };
-        let ops = block.read().unwrap().ops();
-        let ops = ops.read().unwrap();
+        let ops = block.re().ops();
+        let ops = ops.re();
         let op = ops.first();
         if op.is_none() {
             return Err(anyhow::anyhow!("Expected 1 op, got 0"));

--- a/xrcf/src/ir/module.rs
+++ b/xrcf/src/ir/module.rs
@@ -8,7 +8,7 @@ use crate::parser::Parse;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
-use crate::shared::RwLockExt;
+use crate::shared::SharedExt;
 use anyhow::Result;
 use std::fmt::Display;
 use std::fmt::Formatter;

--- a/xrcf/src/ir/module.rs
+++ b/xrcf/src/ir/module.rs
@@ -8,6 +8,7 @@ use crate::parser::Parse;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
+use crate::shared::RwLockExt;
 use anyhow::Result;
 use std::fmt::Display;
 use std::fmt::Formatter;
@@ -90,7 +91,7 @@ impl Parse for ModuleOp {
         let op = Arc::new(RwLock::new(op));
 
         let region = parser.parse_region(op.clone());
-        let mut operation = operation.try_write().unwrap();
+        let mut operation = operation.wr();
         operation.set_region(Some(region?));
         operation.set_parent(parent.clone());
 

--- a/xrcf/src/ir/op.rs
+++ b/xrcf/src/ir/op.rs
@@ -10,6 +10,7 @@ use crate::ir::Value;
 use crate::ir::Values;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
+use crate::shared::RwLockExt;
 use anyhow::Result;
 use std::fmt::Display;
 use std::fmt::Formatter;
@@ -42,7 +43,7 @@ pub trait Op {
         {
             let name = Self::operation_name();
             let operation_write = operation.clone();
-            let mut operation_write = operation_write.try_write().unwrap();
+            let mut operation_write = operation_write.wr();
             operation_write.set_name(name);
         }
         let op = Self::new(operation);
@@ -145,13 +146,13 @@ pub trait Op {
         };
         {
             for result in results.vec().try_read().unwrap().iter() {
-                let mut result = result.try_write().unwrap();
+                let mut result = result.wr();
                 if let Value::OpResult(res) = &mut *result {
                     res.set_defining_op(Some(new.clone()));
                 }
             }
             let new_read = new.try_read().unwrap();
-            let mut new_operation = new_read.operation().try_write().unwrap();
+            let mut new_operation = new_read.operation().wr();
             new_operation.set_results(results.clone());
         }
         let old_operation = self.operation().try_read().unwrap();
@@ -183,7 +184,7 @@ pub trait Op {
     }
     fn set_parent(&self, parent: Arc<RwLock<Block>>) {
         let operation = self.operation();
-        let mut operation = operation.try_write().unwrap();
+        let mut operation = operation.wr();
         operation.set_parent(Some(parent));
     }
     /// Return the result at the given index.

--- a/xrcf/src/ir/op.rs
+++ b/xrcf/src/ir/op.rs
@@ -1,7 +1,6 @@
 use crate::convert::RewriteResult;
 use crate::ir::Attribute;
 use crate::ir::Block;
-use crate::ir::GuardedBlock;
 use crate::ir::GuardedRegion;
 use crate::ir::Operation;
 use crate::ir::OperationName;

--- a/xrcf/src/ir/op.rs
+++ b/xrcf/src/ir/op.rs
@@ -116,11 +116,11 @@ pub trait Op {
     }
     /// Replace self with `new` by moving the results of the old operation to
     /// the results of the specified new op, and pointing the
-    /// `result.defining_op` to the new op.  In effect, this makes all the uses
+    /// `result.defining_op` to the new op. In effect, this makes all the uses
     /// of the old op refer to the new op instead.
     ///
     /// Note that this function assumes that `self` will be dropped after this
-    /// function call.  Therefore, the old op can still have references to
+    /// function call. Therefore, the old op can still have references to
     /// objects that are now part of the new op.
     fn replace(&self, new: Arc<RwLock<dyn Op>>) {
         let parent = self.operation().rd().parent();
@@ -144,30 +144,24 @@ pub trait Op {
     /// not located inside the main region of the op. For example, the `scf.if`
     /// operation contains two regions: the "then" region and the "else" region.
     fn ops(&self) -> Vec<Arc<RwLock<dyn Op>>> {
-        let region = self.region();
-        if let Some(region) = region {
+        if let Some(region) = self.region() {
             region.ops()
         } else {
             vec![]
         }
     }
     fn parent_op(&self) -> Option<Arc<RwLock<dyn Op>>> {
-        let operation = self.operation().rd();
-        operation.parent_op()
+        self.operation().rd().parent_op()
     }
     fn set_parent(&self, parent: Arc<RwLock<Block>>) {
-        let operation = self.operation();
-        let mut operation = operation.wr();
-        operation.set_parent(Some(parent));
+        self.operation().wr().set_parent(Some(parent));
     }
     /// Return the result at the given index.
     ///
     /// Convenience function which makes it easier to set an operand to the
     /// result of an operation.
     fn result(&self, index: usize) -> Arc<RwLock<Value>> {
-        let operation = self.operation().rd();
-        let value = operation.result(index).unwrap();
-        value
+        self.operation().rd().result(index).unwrap()
     }
     /// Display the operation with the given indentation.
     ///
@@ -176,8 +170,7 @@ pub trait Op {
     /// `display` recursively while continuously increasing the indentation
     /// level.
     fn display(&self, f: &mut Formatter<'_>, _indent: i32) -> std::fmt::Result {
-        let operation = self.operation().rd();
-        operation.display(f, 0)
+        self.operation().rd().display(f, 0)
     }
 }
 
@@ -201,8 +194,7 @@ impl UnsetOp {
         UnsetOp(op)
     }
     pub fn set_parent(&self, parent: Arc<RwLock<Block>>) -> Arc<RwLock<dyn Op>> {
-        let op = self.0.rd();
-        op.set_parent(parent);
+        self.0.rd().set_parent(parent);
         self.0.clone()
     }
 }

--- a/xrcf/src/ir/op.rs
+++ b/xrcf/src/ir/op.rs
@@ -10,7 +10,7 @@ use crate::ir::Value;
 use crate::ir::Values;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
-use crate::shared::RwLockExt;
+use crate::shared::SharedExt;
 use anyhow::Result;
 use std::fmt::Display;
 use std::fmt::Formatter;

--- a/xrcf/src/ir/op.rs
+++ b/xrcf/src/ir/op.rs
@@ -10,6 +10,7 @@ use crate::ir::Value;
 use crate::ir::Values;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
+use crate::shared::Shared;
 use crate::shared::SharedExt;
 use anyhow::Result;
 use std::fmt::Display;

--- a/xrcf/src/ir/op.rs
+++ b/xrcf/src/ir/op.rs
@@ -59,7 +59,7 @@ pub trait Op {
     where
         Self: Sized,
     {
-        let operation = Arc::new(RwLock::new(operation));
+        let operation = Shared::new(operation.into());
         Self::from_operation_arc(operation)
     }
     fn as_any(&self) -> &dyn std::any::Any;

--- a/xrcf/src/ir/op.rs
+++ b/xrcf/src/ir/op.rs
@@ -68,11 +68,11 @@ pub trait Op {
     /// This is a convenience method for `self.operation().name()`.
     /// Unlike `self.operation_name()`, this method is available on a `dyn Op`.
     fn name(&self) -> OperationName {
-        let operation = self.operation().read().unwrap();
+        let operation = self.operation().re();
         operation.name()
     }
     fn region(&self) -> Option<Arc<RwLock<Region>>> {
-        let operation = self.operation().read().unwrap();
+        let operation = self.operation().re();
         operation.region()
     }
     /// Returns the values which this `Op` assigns to.
@@ -80,7 +80,7 @@ pub trait Op {
     /// But for some other ops like `FuncOp`, this can be different.
     fn assignments(&self) -> Result<Values> {
         let operation = self.operation();
-        let operation = operation.read().unwrap();
+        let operation = operation.re();
         let results = operation.results();
         Ok(results.clone())
     }
@@ -100,10 +100,10 @@ pub trait Op {
         false
     }
     fn attribute(&self, key: &str) -> Option<Arc<dyn Attribute>> {
-        let operation = self.operation().read().unwrap();
+        let operation = self.operation().re();
         let attributes = operation.attributes();
         let attributes = attributes.map();
-        let attributes = attributes.read().unwrap();
+        let attributes = attributes.re();
         let value = attributes.get(key)?;
         Some(value.clone())
     }
@@ -127,9 +127,9 @@ pub trait Op {
     }
     /// Remove the operation from its parent block.
     fn remove(&self) {
-        let operation = self.operation().read().unwrap();
+        let operation = self.operation().re();
         let block = operation.parent().expect("no parent");
-        let block = block.read().unwrap();
+        let block = block.re();
         block.remove(self.operation().clone());
     }
     /// Replace self with `new` by moving the results of the old operation to

--- a/xrcf/src/ir/op.rs
+++ b/xrcf/src/ir/op.rs
@@ -125,14 +125,12 @@ pub trait Op {
     fn replace(&self, new: Arc<RwLock<dyn Op>>) {
         let parent = self.operation().rd().parent();
         let results = self.operation().rd().results();
-        {
-            for result in results.clone().into_iter() {
-                if let Value::OpResult(res) = &mut *result.wr() {
-                    res.set_defining_op(Some(new.clone()));
-                }
+        for result in results.clone().into_iter() {
+            if let Value::OpResult(res) = &mut *result.wr() {
+                res.set_defining_op(Some(new.clone()));
             }
-            new.rd().operation().wr().set_results(results.clone());
         }
+        new.rd().operation().wr().set_results(results);
         // Root ops do not have a parent, so in that case we don't need to
         // update the parent.
         if let Some(parent) = parent {

--- a/xrcf/src/ir/op_operand.rs
+++ b/xrcf/src/ir/op_operand.rs
@@ -8,6 +8,7 @@ use crate::ir::Value;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
+use crate::shared::Shared;
 use crate::shared::SharedExt;
 use anyhow::Result;
 use std::fmt::Display;
@@ -110,7 +111,7 @@ impl OpOperands {
     }
     pub fn from_vec(operands: Vec<Arc<RwLock<OpOperand>>>) -> Self {
         OpOperands {
-            operands: Shared::new(operands),
+            operands: Shared::new(operands.into()),
         }
     }
     pub fn set_operand(&mut self, index: usize, operand: Arc<RwLock<OpOperand>>) {
@@ -139,7 +140,7 @@ impl OpOperands {
 impl Default for OpOperands {
     fn default() -> Self {
         OpOperands {
-            operands: Shared::new(vec![]),
+            operands: Shared::new(vec![].into()),
         }
     }
 }
@@ -246,7 +247,7 @@ impl<T: ParserDispatch> Parser<T> {
             }
         }
         let operands = OpOperands {
-            operands: Shared::new(arguments),
+            operands: Shared::new(arguments.into()),
         };
         Ok(operands)
     }

--- a/xrcf/src/ir/op_operand.rs
+++ b/xrcf/src/ir/op_operand.rs
@@ -8,6 +8,7 @@ use crate::ir::Value;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
+use crate::shared::RwLockExt;
 use anyhow::Result;
 use std::fmt::Display;
 use std::fmt::Formatter;
@@ -94,7 +95,7 @@ impl GuardedOpOperand for Arc<RwLock<OpOperand>> {
         self.try_read().unwrap().value()
     }
     fn set_value(&mut self, value: Arc<RwLock<Value>>) {
-        self.try_write().unwrap().set_value(value);
+        self.wr().set_value(value);
     }
 }
 
@@ -113,7 +114,7 @@ impl OpOperands {
         }
     }
     pub fn set_operand(&mut self, index: usize, operand: Arc<RwLock<OpOperand>>) {
-        let mut operands = self.operands.try_write().unwrap();
+        let mut operands = self.operands.wr();
         if operands.len() == index {
             operands.push(operand);
         } else {

--- a/xrcf/src/ir/op_operand.rs
+++ b/xrcf/src/ir/op_operand.rs
@@ -30,8 +30,7 @@ impl OpOperand {
         OpOperand { value }
     }
     pub fn name(&self) -> String {
-        let value = self.value.rd();
-        value.name().expect("no name")
+        self.value().rd().name().expect("no name")
     }
     pub fn value(&self) -> Arc<RwLock<Value>> {
         self.value.clone()
@@ -44,9 +43,7 @@ impl OpOperand {
     ///
     /// Returns `None` if the operand is not a [Value::OpResult].
     pub fn defining_op(&self) -> Option<Arc<RwLock<dyn Op>>> {
-        let value = self.value();
-        let value = &*value.rd();
-        match value {
+        match &*self.value().rd() {
             Value::BlockArgument(_) => None,
             Value::BlockLabel(_) => None,
             Value::BlockPtr(_) => None,
@@ -57,20 +54,16 @@ impl OpOperand {
         }
     }
     pub fn display_with_type(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let typ = self.typ().unwrap();
-        let typ = typ.rd();
-        write!(f, "{self} : {typ}")
+        write!(f, "{self} : {}", self.typ().unwrap().rd())
     }
     pub fn typ(&self) -> Result<Arc<RwLock<dyn Type>>> {
-        let value = self.value.rd();
-        value.typ()
+        self.value.rd().typ()
     }
 }
 
 impl Display for OpOperand {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let value = self.value.rd();
-        match &*value {
+        match &*self.value.rd() {
             Value::Constant(constant) => write!(f, "{constant}"),
             _ => write!(f, "{}", self.name()),
         }

--- a/xrcf/src/ir/op_operand.rs
+++ b/xrcf/src/ir/op_operand.rs
@@ -30,7 +30,7 @@ impl OpOperand {
         OpOperand { value }
     }
     pub fn name(&self) -> String {
-        let value = self.value.re();
+        let value = self.value.rd();
         value.name().expect("no name")
     }
     pub fn value(&self) -> Arc<RwLock<Value>> {
@@ -45,7 +45,7 @@ impl OpOperand {
     /// Returns `None` if the operand is not a [Value::OpResult].
     pub fn defining_op(&self) -> Option<Arc<RwLock<dyn Op>>> {
         let value = self.value();
-        let value = &*value.re();
+        let value = &*value.rd();
         match value {
             Value::BlockArgument(_) => None,
             Value::BlockLabel(_) => None,
@@ -58,18 +58,18 @@ impl OpOperand {
     }
     pub fn display_with_type(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let typ = self.typ().unwrap();
-        let typ = typ.re();
+        let typ = typ.rd();
         write!(f, "{self} : {typ}")
     }
     pub fn typ(&self) -> Result<Arc<RwLock<dyn Type>>> {
-        let value = self.value.re();
+        let value = self.value.rd();
         value.typ()
     }
 }
 
 impl Display for OpOperand {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let value = self.value.re();
+        let value = self.value.rd();
         match &*value {
             Value::Constant(constant) => write!(f, "{constant}"),
             _ => write!(f, "{}", self.name()),
@@ -86,14 +86,14 @@ pub trait GuardedOpOperand {
 
 impl GuardedOpOperand for Arc<RwLock<OpOperand>> {
     fn defining_op(&self) -> Option<Arc<RwLock<dyn Op>>> {
-        let op = self.re();
+        let op = self.rd();
         op.defining_op()
     }
     fn typ(&self) -> Result<Arc<RwLock<dyn Type>>> {
-        self.re().typ()
+        self.rd().typ()
     }
     fn value(&self) -> Arc<RwLock<Value>> {
-        self.re().value()
+        self.rd().value()
     }
     fn set_value(&mut self, value: Arc<RwLock<Value>>) {
         self.wr().set_value(value);
@@ -123,13 +123,13 @@ impl OpOperands {
         }
     }
     pub fn display_with_types(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let operands = self.operands.re();
+        let operands = self.operands.rd();
         if !operands.is_empty() {
             for (index, operand) in operands.iter().enumerate() {
                 if 0 < index {
                     write!(f, ", ")?;
                 }
-                let operand = operand.re();
+                let operand = operand.rd();
                 operand.display_with_type(f)?;
             }
         }
@@ -152,7 +152,7 @@ impl Display for OpOperands {
             .try_read()
             .unwrap()
             .iter()
-            .map(|o| o.re().to_string())
+            .map(|o| o.rd().to_string())
             .collect::<Vec<String>>()
             .join(", ");
         write!(f, "{}", joined)

--- a/xrcf/src/ir/op_operand.rs
+++ b/xrcf/src/ir/op_operand.rs
@@ -22,7 +22,7 @@ pub struct OpOperand {
 impl OpOperand {
     pub fn from_block(block: Arc<RwLock<Block>>) -> Self {
         let value = Value::from_block(block);
-        let value = Arc::new(RwLock::new(value));
+        let value = Shared::new(value.into());
         OpOperand { value }
     }
     pub fn new(value: Arc<RwLock<Value>>) -> Self {
@@ -110,7 +110,7 @@ impl OpOperands {
     }
     pub fn from_vec(operands: Vec<Arc<RwLock<OpOperand>>>) -> Self {
         OpOperands {
-            operands: Arc::new(RwLock::new(operands)),
+            operands: Shared::new(operands),
         }
     }
     pub fn set_operand(&mut self, index: usize, operand: Arc<RwLock<OpOperand>>) {
@@ -139,7 +139,7 @@ impl OpOperands {
 impl Default for OpOperands {
     fn default() -> Self {
         OpOperands {
-            operands: Arc::new(RwLock::new(vec![])),
+            operands: Shared::new(vec![]),
         }
     }
 }
@@ -184,22 +184,22 @@ impl<T: ParserDispatch> Parser<T> {
                 }
             };
             let operand = OpOperand::new(assignment);
-            Ok(Arc::new(RwLock::new(operand)))
+            Ok(Shared::new(operand.into()))
         } else if next.kind == TokenKind::CaretIdentifier {
             let identifier = self.expect(TokenKind::CaretIdentifier)?;
             let label = BlockLabel::new(identifier.lexeme.clone());
             let label = Value::BlockLabel(label);
-            let label = Arc::new(RwLock::new(label));
+            let label = Shared::new(label.into());
             let operand = OpOperand::new(label);
-            Ok(Arc::new(RwLock::new(operand)))
+            Ok(Shared::new(operand.into()))
         } else if next.kind == TokenKind::String {
             let text = self.parse_string()?;
             let text = Arc::new(text);
             let text = Constant::new(text);
             let text = Value::Constant(text);
-            let text = Arc::new(RwLock::new(text));
+            let text = Shared::new(text.into());
             let operand = OpOperand::new(text);
-            Ok(Arc::new(RwLock::new(operand)))
+            Ok(Shared::new(operand.into()))
         } else {
             let msg = "Expected operand.";
             let msg = self.error(&next, msg);
@@ -246,7 +246,7 @@ impl<T: ParserDispatch> Parser<T> {
             }
         }
         let operands = OpOperands {
-            operands: Arc::new(RwLock::new(arguments)),
+            operands: Shared::new(arguments),
         };
         Ok(operands)
     }

--- a/xrcf/src/ir/op_operand.rs
+++ b/xrcf/src/ir/op_operand.rs
@@ -105,6 +105,14 @@ pub struct OpOperands {
     operands: Arc<RwLock<Vec<Arc<RwLock<OpOperand>>>>>,
 }
 
+impl IntoIterator for OpOperands {
+    type Item = Arc<RwLock<OpOperand>>;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.operands.rd().clone().into_iter()
+    }
+}
+
 impl OpOperands {
     pub fn vec(&self) -> Arc<RwLock<Vec<Arc<RwLock<OpOperand>>>>> {
         self.operands.clone()

--- a/xrcf/src/ir/op_operand.rs
+++ b/xrcf/src/ir/op_operand.rs
@@ -8,7 +8,7 @@ use crate::ir::Value;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
-use crate::shared::RwLockExt;
+use crate::shared::SharedExt;
 use anyhow::Result;
 use std::fmt::Display;
 use std::fmt::Formatter;

--- a/xrcf/src/ir/operation.rs
+++ b/xrcf/src/ir/operation.rs
@@ -125,7 +125,7 @@ pub fn display_region_inside_func(
 ) -> std::fmt::Result {
     let region = operation.region();
     if let Some(region) = region {
-        let region = region.re();
+        let region = region.rd();
         let blocks = region.blocks();
         if blocks.into_iter().next().is_none() {
             write!(f, "\n")
@@ -203,18 +203,18 @@ impl Operation {
     pub fn blocks(&self) -> Vec<Arc<RwLock<Block>>> {
         let region = self.region();
         let region = region.expect("expected region");
-        let region = region.re();
+        let region = region.rd();
         region.blocks().into_iter().collect::<Vec<_>>()
     }
     pub fn operand_types(&self) -> Types {
         let operands = self.operands.vec();
-        let operands = operands.re();
-        let operand_types = operands.iter().map(|o| o.re().typ().unwrap()).collect();
+        let operands = operands.rd();
+        let operand_types = operands.iter().map(|o| o.rd().typ().unwrap()).collect();
         Types::from_vec(operand_types)
     }
     pub fn operand(&self, index: usize) -> Option<Arc<RwLock<OpOperand>>> {
         let operands = self.operands.vec();
-        let operands = operands.re();
+        let operands = operands.rd();
         operands.get(index).cloned()
     }
     pub fn operands_mut(&mut self) -> &mut OpOperands {
@@ -228,7 +228,7 @@ impl Operation {
     }
     pub fn result(&self, index: usize) -> Option<Arc<RwLock<Value>>> {
         let results = self.results.vec();
-        let results = results.re();
+        let results = results.rd();
         results.get(index).cloned()
     }
     /// Get the single result type of the operation.
@@ -237,22 +237,22 @@ impl Operation {
     pub fn result_type(&self, index: usize) -> Option<Arc<RwLock<dyn Type>>> {
         let results = self.results();
         let results = results.vec();
-        let results = results.re();
+        let results = results.rd();
         let result = results.get(index).unwrap();
-        let result = result.re();
+        let result = result.rd();
         Some(result.typ().unwrap())
     }
     pub fn result_names(&self) -> Vec<String> {
         let results = self.results();
         let results = results.vec();
-        let results = results.re();
+        let results = results.rd();
         let mut result_names = vec![];
         for result in results.iter() {
-            let result = result.re();
+            let result = result.rd();
             let name = match &*result {
                 Value::BlockArgument(arg) => {
                     let name = arg.name();
-                    let name = name.re();
+                    let name = name.rd();
                     match &*name {
                         BlockArgumentName::Anonymous => continue,
                         BlockArgumentName::Name(name) => name.to_string(),
@@ -265,7 +265,7 @@ impl Operation {
                 Value::FuncResult(_) => continue,
                 Value::OpResult(res) => {
                     let name = res.name();
-                    let name = name.re();
+                    let name = name.rd();
                     match &*name {
                         Some(name) => name.to_string(),
                         None => continue,
@@ -289,13 +289,13 @@ impl Operation {
             Some(parent) => parent,
             None => return None,
         };
-        let parent = parent.re();
+        let parent = parent.rd();
         let parent = parent.parent();
         let parent = match parent {
             Some(parent) => parent,
             None => return None,
         };
-        let parent = parent.re();
+        let parent = parent.rd();
         let parent = parent.parent();
         let parent = match parent {
             Some(parent) => parent,
@@ -338,7 +338,7 @@ impl Operation {
     pub fn set_result_type(&self, index: usize, result_type: Arc<RwLock<dyn Type>>) -> Result<()> {
         let results = self.results();
         let results = results.vec();
-        let results = results.re();
+        let results = results.rd();
         let result = results.get(index).unwrap();
         let mut result = result.try_write().unwrap();
         result.set_type(result_type);
@@ -375,7 +375,7 @@ impl Operation {
             }
         };
         let ops = parent.ops();
-        let ops = ops.re();
+        let ops = ops.rd();
         ops[..index].to_vec()
     }
     pub fn successors(&self) -> Vec<Arc<RwLock<dyn Op>>> {
@@ -391,12 +391,12 @@ impl Operation {
             }
         };
         let ops = parent.ops();
-        let ops = ops.re();
+        let ops = ops.rd();
         ops[index + 1..].to_vec()
     }
     pub fn update_result_types(&mut self, result_types: Vec<Arc<RwLock<dyn Type>>>) -> Result<()> {
         let mut results = self.results();
-        if results.vec().re().is_empty() {
+        if results.vec().rd().is_empty() {
             return Err(anyhow::anyhow!("Expected results to have been set"));
         }
         results.update_types(result_types)?;
@@ -428,13 +428,13 @@ impl Operation {
     pub fn users(&self) -> Users {
         let mut out = Vec::new();
         let results = self.results().vec();
-        let results = results.re();
+        let results = results.rd();
         let defines_result = results.len() > 0;
         if !defines_result {
             return Users::HasNoOpResults;
         }
         for result in results.iter() {
-            let result = result.re();
+            let result = result.rd();
             let result_users = result.users();
             match result_users {
                 Users::OpOperands(users) => {
@@ -455,7 +455,7 @@ impl Operation {
         }
         write!(f, "{}", self.name())?;
         let operands = self.operands();
-        if !operands.vec().re().is_empty() {
+        if !operands.vec().rd().is_empty() {
             write!(f, " {}", operands)?;
         }
         write!(f, "{}", self.attributes())?;
@@ -463,7 +463,7 @@ impl Operation {
         if !result_types.vec().is_empty() {
             write!(f, " :")?;
             for result_type in result_types.vec().iter() {
-                write!(f, " {}", result_type.re())?;
+                write!(f, " {}", result_type.rd())?;
             }
         }
         display_region_inside_func(f, self, indent)
@@ -520,50 +520,50 @@ pub trait GuardedOperation {
 
 impl GuardedOperation for Arc<RwLock<Operation>> {
     fn arguments(&self) -> Values {
-        self.re().arguments()
+        self.rd().arguments()
     }
     fn attributes(&self) -> Attributes {
-        self.re().attributes()
+        self.rd().attributes()
     }
     fn blocks(&self) -> Vec<Arc<RwLock<Block>>> {
-        self.re().blocks()
+        self.rd().blocks()
     }
     fn display(&self, f: &mut Formatter<'_>, indent: i32) -> std::fmt::Result {
-        self.re().display(f, indent)
+        self.rd().display(f, indent)
     }
     fn name(&self) -> OperationName {
-        self.re().name()
+        self.rd().name()
     }
     fn operand(&self, index: usize) -> Option<Arc<RwLock<OpOperand>>> {
-        self.re().operand(index)
+        self.rd().operand(index)
     }
     fn operands(&self) -> OpOperands {
-        self.re().operands()
+        self.rd().operands()
     }
     fn parent(&self) -> Option<Arc<RwLock<Block>>> {
-        let operation = self.re();
+        let operation = self.rd();
         operation.parent()
     }
     fn predecessors(&self) -> Vec<Arc<RwLock<dyn Op>>> {
-        self.re().predecessors()
+        self.rd().predecessors()
     }
     fn region(&self) -> Option<Arc<RwLock<Region>>> {
-        self.re().region()
+        self.rd().region()
     }
     fn rename_variables(&self, renamer: &dyn VariableRenamer) -> Result<()> {
-        self.re().rename_variables(renamer)
+        self.rd().rename_variables(renamer)
     }
     fn result(&self, index: usize) -> Option<Arc<RwLock<Value>>> {
-        self.re().result(index)
+        self.rd().result(index)
     }
     fn result_names(&self) -> Vec<String> {
-        self.re().result_names()
+        self.rd().result_names()
     }
     fn result_type(&self, index: usize) -> Option<Arc<RwLock<dyn Type>>> {
-        self.re().result_type(index)
+        self.rd().result_type(index)
     }
     fn results(&self) -> Values {
-        self.re().results()
+        self.rd().results()
     }
     fn set_anonymous_result(&self, result_type: Arc<RwLock<dyn Type>>) -> Result<()> {
         self.try_write().unwrap().set_anonymous_result(result_type)
@@ -593,6 +593,6 @@ impl GuardedOperation for Arc<RwLock<Operation>> {
         self.try_write().unwrap().set_results(results);
     }
     fn successors(&self) -> Vec<Arc<RwLock<dyn Op>>> {
-        self.re().successors()
+        self.rd().successors()
     }
 }

--- a/xrcf/src/ir/operation.rs
+++ b/xrcf/src/ir/operation.rs
@@ -1,7 +1,6 @@
 use crate::ir::AnonymousResult;
 use crate::ir::Attributes;
 use crate::ir::Block;
-use crate::shared::Shared;
 use crate::ir::BlockArgumentName;
 use crate::ir::GuardedBlock;
 use crate::ir::Op;
@@ -18,6 +17,7 @@ use crate::ir::Values;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
+use crate::shared::Shared;
 use crate::shared::SharedExt;
 use anyhow::Result;
 use std::default::Default;

--- a/xrcf/src/ir/operation.rs
+++ b/xrcf/src/ir/operation.rs
@@ -2,6 +2,7 @@ use crate::ir::AnonymousResult;
 use crate::ir::Attributes;
 use crate::ir::Block;
 use crate::ir::BlockArgumentName;
+use crate::ir::Blocks;
 use crate::ir::GuardedBlock;
 use crate::ir::Op;
 use crate::ir::OpOperand;
@@ -126,8 +127,7 @@ pub fn display_region_inside_func(
     let region = operation.region();
     if let Some(region) = region {
         let region = region.rd();
-        let blocks = region.blocks();
-        if blocks.into_iter().next().is_none() {
+        if region.blocks().into_iter().next().is_none() {
             write!(f, "\n")
         } else {
             region.display(f, indent)
@@ -200,11 +200,8 @@ impl Operation {
     pub fn operands(&self) -> OpOperands {
         self.operands.clone()
     }
-    pub fn blocks(&self) -> Vec<Arc<RwLock<Block>>> {
-        let region = self.region();
-        let region = region.expect("expected region");
-        let region = region.rd();
-        region.blocks().into_iter().collect::<Vec<_>>()
+    pub fn blocks(&self) -> Blocks {
+        self.region().expect("no region").rd().blocks()
     }
     pub fn operand_types(&self) -> Types {
         let operands = self.operands.vec();
@@ -493,7 +490,6 @@ impl Display for Operation {
 pub trait GuardedOperation {
     fn arguments(&self) -> Values;
     fn attributes(&self) -> Attributes;
-    fn blocks(&self) -> Vec<Arc<RwLock<Block>>>;
     fn display(&self, f: &mut Formatter<'_>, indent: i32) -> std::fmt::Result;
     fn name(&self) -> OperationName;
     fn operand(&self, index: usize) -> Option<Arc<RwLock<OpOperand>>>;
@@ -524,9 +520,6 @@ impl GuardedOperation for Arc<RwLock<Operation>> {
     }
     fn attributes(&self) -> Attributes {
         self.rd().attributes()
-    }
-    fn blocks(&self) -> Vec<Arc<RwLock<Block>>> {
-        self.rd().blocks()
     }
     fn display(&self, f: &mut Formatter<'_>, indent: i32) -> std::fmt::Result {
         self.rd().display(f, indent)

--- a/xrcf/src/ir/operation.rs
+++ b/xrcf/src/ir/operation.rs
@@ -1,6 +1,7 @@
 use crate::ir::AnonymousResult;
 use crate::ir::Attributes;
 use crate::ir::Block;
+use crate::shared::Shared;
 use crate::ir::BlockArgumentName;
 use crate::ir::GuardedBlock;
 use crate::ir::Op;
@@ -351,7 +352,7 @@ impl Operation {
         for result_type in result_types.iter() {
             let func_result = AnonymousResult::new(result_type.clone());
             let value = Value::FuncResult(func_result);
-            let value = Arc::new(RwLock::new(value));
+            let value = Shared::new(value.into());
             results.push(value);
         }
         Ok(())
@@ -411,7 +412,7 @@ impl Operation {
         result.set_name(name);
         result.set_typ(typ);
         let op_result = Value::OpResult(result);
-        let op_result = Arc::new(RwLock::new(op_result));
+        let op_result = Shared::new(op_result.into());
         vec.push(op_result.clone());
         UnsetOpResult::new(op_result)
     }

--- a/xrcf/src/ir/region.rs
+++ b/xrcf/src/ir/region.rs
@@ -4,6 +4,7 @@ use crate::ir::Blocks;
 use crate::ir::GuardedBlock;
 use crate::ir::Op;
 use crate::ir::UnsetBlock;
+use crate::shared::Shared;
 use crate::shared::SharedExt;
 use std::fmt::Display;
 use std::fmt::Formatter;
@@ -91,7 +92,7 @@ impl Region {
     }
     pub fn add_empty_block(&self) -> UnsetBlock {
         let block = Block::default();
-        let block = Arc::new(RwLock::new(block));
+        let block = Shared::new(block.into());
         let blocks = self.blocks();
         let blocks = blocks.vec();
         let mut blocks = blocks.wr();
@@ -102,7 +103,7 @@ impl Region {
         let index = self.index_of(&block.re()).unwrap();
 
         let new = Block::default();
-        let new = Arc::new(RwLock::new(new));
+        let new = Shared::new(new.into());
         let blocks = self.blocks();
         let blocks = blocks.vec();
         let mut blocks = blocks.wr();
@@ -159,7 +160,7 @@ impl Display for Region {
 impl Default for Region {
     fn default() -> Self {
         Self {
-            blocks: Blocks::new(Arc::new(RwLock::new(vec![]))),
+            blocks: Blocks::new(Shared::new(vec![].into())),
             parent: None,
         }
     }

--- a/xrcf/src/ir/region.rs
+++ b/xrcf/src/ir/region.rs
@@ -4,6 +4,7 @@ use crate::ir::Blocks;
 use crate::ir::GuardedBlock;
 use crate::ir::Op;
 use crate::ir::UnsetBlock;
+use crate::shared::RwLockExt;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::sync::Arc;
@@ -93,7 +94,7 @@ impl Region {
         let block = Arc::new(RwLock::new(block));
         let blocks = self.blocks();
         let blocks = blocks.vec();
-        let mut blocks = blocks.try_write().unwrap();
+        let mut blocks = blocks.wr();
         blocks.push(block.clone());
         UnsetBlock::new(block)
     }
@@ -104,7 +105,7 @@ impl Region {
         let new = Arc::new(RwLock::new(new));
         let blocks = self.blocks();
         let blocks = blocks.vec();
-        let mut blocks = blocks.try_write().unwrap();
+        let mut blocks = blocks.wr();
         blocks.insert(index, new.clone());
         UnsetBlock::new(new)
     }
@@ -192,10 +193,10 @@ impl GuardedRegion for Arc<RwLock<Region>> {
         self.try_read().unwrap().ops()
     }
     fn set_blocks(&self, blocks: Blocks) {
-        self.try_write().unwrap().set_blocks(blocks);
+        self.wr().set_blocks(blocks);
     }
     fn set_parent(&self, parent: Option<Arc<RwLock<dyn Op>>>) {
-        self.try_write().unwrap().set_parent(parent);
+        self.wr().set_parent(parent);
     }
     fn unique_block_name(&self) -> String {
         self.try_read().unwrap().unique_block_name()

--- a/xrcf/src/ir/region.rs
+++ b/xrcf/src/ir/region.rs
@@ -32,10 +32,10 @@ pub struct Region {
 fn set_fresh_block_labels(blocks: &Vec<Arc<RwLock<Block>>>) {
     let mut label_index: usize = 1;
     for block in blocks.iter() {
-        let block = block.re();
+        let block = block.rd();
         let label_prefix = block.label_prefix();
         let label = block.label();
-        let label_read = label.re();
+        let label_read = label.rd();
         match &*label_read {
             BlockName::Name(_name) => {
                 drop(label_read);
@@ -74,7 +74,7 @@ impl Region {
         let blocks = self.blocks();
         for block in blocks.into_iter() {
             let ops = block.ops();
-            let ops = ops.re();
+            let ops = ops.rd();
             for op in ops.iter() {
                 result.push(op.clone());
             }
@@ -100,7 +100,7 @@ impl Region {
         UnsetBlock::new(block)
     }
     pub fn add_empty_block_before(&self, block: Arc<RwLock<Block>>) -> UnsetBlock {
-        let index = self.index_of(&block.re()).unwrap();
+        let index = self.index_of(&block.rd()).unwrap();
 
         let new = Block::default();
         let new = Shared::new(new.into());
@@ -117,10 +117,10 @@ impl Region {
         write!(f, " {{\n")?;
         let blocks = self.blocks();
         let blocks = blocks.vec();
-        let blocks = blocks.re();
+        let blocks = blocks.rd();
         set_fresh_block_labels(&blocks);
         for block in blocks.iter() {
-            let block = block.re();
+            let block = block.rd();
             block.display(f, indent + 1)?;
         }
         let spaces = crate::ir::spaces(indent);
@@ -130,9 +130,9 @@ impl Region {
     pub fn unique_block_name(&self) -> String {
         let mut new_name: i32 = 0;
         for block in self.blocks().into_iter() {
-            let block = block.re();
+            let block = block.rd();
             let label = block.label();
-            let label = label.re();
+            let label = label.rd();
             match &*label {
                 BlockName::Name(name) => {
                     let name = name.trim_start_matches("bb").trim_start_matches("^bb");
@@ -179,19 +179,19 @@ pub trait GuardedRegion {
 
 impl GuardedRegion for Arc<RwLock<Region>> {
     fn add_empty_block(&self) -> UnsetBlock {
-        self.re().add_empty_block()
+        self.rd().add_empty_block()
     }
     fn add_empty_block_before(&self, block: Arc<RwLock<Block>>) -> UnsetBlock {
-        self.re().add_empty_block_before(block)
+        self.rd().add_empty_block_before(block)
     }
     fn blocks(&self) -> Blocks {
-        self.re().blocks()
+        self.rd().blocks()
     }
     fn display(&self, f: &mut Formatter<'_>, indent: i32) -> std::fmt::Result {
-        self.re().display(f, indent)
+        self.rd().display(f, indent)
     }
     fn ops(&self) -> Vec<Arc<RwLock<dyn Op>>> {
-        self.re().ops()
+        self.rd().ops()
     }
     fn set_blocks(&self, blocks: Blocks) {
         self.wr().set_blocks(blocks);
@@ -200,6 +200,6 @@ impl GuardedRegion for Arc<RwLock<Region>> {
         self.wr().set_parent(parent);
     }
     fn unique_block_name(&self) -> String {
-        self.re().unique_block_name()
+        self.rd().unique_block_name()
     }
 }

--- a/xrcf/src/ir/region.rs
+++ b/xrcf/src/ir/region.rs
@@ -73,7 +73,7 @@ impl Region {
         let blocks = self.blocks();
         for block in blocks.into_iter() {
             let ops = block.ops();
-            let ops = ops.read().unwrap();
+            let ops = ops.re();
             for op in ops.iter() {
                 result.push(op.clone());
             }

--- a/xrcf/src/ir/region.rs
+++ b/xrcf/src/ir/region.rs
@@ -4,7 +4,7 @@ use crate::ir::Blocks;
 use crate::ir::GuardedBlock;
 use crate::ir::Op;
 use crate::ir::UnsetBlock;
-use crate::shared::RwLockExt;
+use crate::shared::SharedExt;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::sync::Arc;

--- a/xrcf/src/ir/region.rs
+++ b/xrcf/src/ir/region.rs
@@ -31,10 +31,10 @@ pub struct Region {
 fn set_fresh_block_labels(blocks: &Vec<Arc<RwLock<Block>>>) {
     let mut label_index: usize = 1;
     for block in blocks.iter() {
-        let block = block.try_read().unwrap();
+        let block = block.re();
         let label_prefix = block.label_prefix();
         let label = block.label();
-        let label_read = label.try_read().unwrap();
+        let label_read = label.re();
         match &*label_read {
             BlockName::Name(_name) => {
                 drop(label_read);
@@ -99,7 +99,7 @@ impl Region {
         UnsetBlock::new(block)
     }
     pub fn add_empty_block_before(&self, block: Arc<RwLock<Block>>) -> UnsetBlock {
-        let index = self.index_of(&block.try_read().unwrap()).unwrap();
+        let index = self.index_of(&block.re()).unwrap();
 
         let new = Block::default();
         let new = Arc::new(RwLock::new(new));
@@ -116,10 +116,10 @@ impl Region {
         write!(f, " {{\n")?;
         let blocks = self.blocks();
         let blocks = blocks.vec();
-        let blocks = blocks.try_read().unwrap();
+        let blocks = blocks.re();
         set_fresh_block_labels(&blocks);
         for block in blocks.iter() {
-            let block = block.try_read().unwrap();
+            let block = block.re();
             block.display(f, indent + 1)?;
         }
         let spaces = crate::ir::spaces(indent);
@@ -129,9 +129,9 @@ impl Region {
     pub fn unique_block_name(&self) -> String {
         let mut new_name: i32 = 0;
         for block in self.blocks().into_iter() {
-            let block = block.try_read().unwrap();
+            let block = block.re();
             let label = block.label();
-            let label = label.try_read().unwrap();
+            let label = label.re();
             match &*label {
                 BlockName::Name(name) => {
                     let name = name.trim_start_matches("bb").trim_start_matches("^bb");
@@ -178,19 +178,19 @@ pub trait GuardedRegion {
 
 impl GuardedRegion for Arc<RwLock<Region>> {
     fn add_empty_block(&self) -> UnsetBlock {
-        self.try_read().unwrap().add_empty_block()
+        self.re().add_empty_block()
     }
     fn add_empty_block_before(&self, block: Arc<RwLock<Block>>) -> UnsetBlock {
-        self.try_read().unwrap().add_empty_block_before(block)
+        self.re().add_empty_block_before(block)
     }
     fn blocks(&self) -> Blocks {
-        self.try_read().unwrap().blocks()
+        self.re().blocks()
     }
     fn display(&self, f: &mut Formatter<'_>, indent: i32) -> std::fmt::Result {
-        self.try_read().unwrap().display(f, indent)
+        self.re().display(f, indent)
     }
     fn ops(&self) -> Vec<Arc<RwLock<dyn Op>>> {
-        self.try_read().unwrap().ops()
+        self.re().ops()
     }
     fn set_blocks(&self, blocks: Blocks) {
         self.wr().set_blocks(blocks);
@@ -199,6 +199,6 @@ impl GuardedRegion for Arc<RwLock<Region>> {
         self.wr().set_parent(parent);
     }
     fn unique_block_name(&self) -> String {
-        self.try_read().unwrap().unique_block_name()
+        self.re().unique_block_name()
     }
 }

--- a/xrcf/src/ir/typ.rs
+++ b/xrcf/src/ir/typ.rs
@@ -210,7 +210,7 @@ impl Display for Types {
             .types
             .iter()
             .map(|t| t.rd().to_string())
-            .collect::<Vec<String>>()
+            .collect::<Vec<_>>()
             .join(", ");
         write!(f, "{}", joined)
     }

--- a/xrcf/src/ir/typ.rs
+++ b/xrcf/src/ir/typ.rs
@@ -43,7 +43,7 @@ pub trait TypeConvert {
     /// This method can be reimplemented to compare types directly instead of
     /// converting to a string first.
     fn convert_type(from: &Arc<RwLock<dyn Type>>) -> Result<Arc<RwLock<dyn Type>>> {
-        let from = from.re();
+        let from = from.rd();
         let typ = Self::convert_str(&from.to_string())?;
         Ok(typ)
     }
@@ -201,7 +201,7 @@ impl Display for Types {
         let joined = self
             .types
             .iter()
-            .map(|t| t.re().to_string())
+            .map(|t| t.rd().to_string())
             .collect::<Vec<String>>()
             .join(", ");
         write!(f, "{}", joined)
@@ -218,11 +218,11 @@ impl<T: ParserDispatch> Parser<T> {
         operand: Arc<RwLock<OpOperand>>,
         typ: Arc<RwLock<dyn Type>>,
     ) -> Result<()> {
-        let operand = operand.re();
+        let operand = operand.rd();
         let operand_typ = operand.typ()?;
-        let operand_typ = operand_typ.re();
+        let operand_typ = operand_typ.rd();
         let token = self.previous().clone();
-        let typ = typ.re();
+        let typ = typ.rd();
         if operand_typ.to_string() != typ.to_string() {
             let msg = format!(
                 "Expected {} due to {}, but got {}",
@@ -270,16 +270,16 @@ impl<T: ParserDispatch> Parser<T> {
     /// ```
     pub fn parse_types_for_op_operands(&mut self, operands: OpOperands) -> Result<()> {
         let types = self.parse_types()?;
-        if types.len() != operands.vec().re().len() {
+        if types.len() != operands.vec().rd().len() {
             let msg = format!(
                 "Expected {} types but got {}",
-                operands.vec().re().len(),
+                operands.vec().rd().len(),
                 types.len()
             );
             return Err(anyhow::anyhow!(msg));
         }
         let operands = operands.vec();
-        let operands = operands.re();
+        let operands = operands.rd();
         for x in operands.iter().zip(types.iter()) {
             let (operand, typ) = x;
             self.verify_type(operand.clone(), typ.clone())?;

--- a/xrcf/src/ir/typ.rs
+++ b/xrcf/src/ir/typ.rs
@@ -181,6 +181,14 @@ pub struct Types {
     types: Vec<Arc<RwLock<dyn Type>>>,
 }
 
+impl IntoIterator for Types {
+    type Item = Arc<RwLock<dyn Type>>;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.types.into_iter()
+    }
+}
+
 impl Types {
     pub fn from_vec(types: Vec<Arc<RwLock<dyn Type>>>) -> Self {
         Self { types }

--- a/xrcf/src/ir/typ.rs
+++ b/xrcf/src/ir/typ.rs
@@ -3,6 +3,7 @@ use crate::ir::OpOperands;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
+use crate::shared::SharedExt;
 use anyhow::Result;
 use std::fmt::Display;
 use std::fmt::Formatter;
@@ -42,7 +43,7 @@ pub trait TypeConvert {
     /// This method can be reimplemented to compare types directly instead of
     /// converting to a string first.
     fn convert_type(from: &Arc<RwLock<dyn Type>>) -> Result<Arc<RwLock<dyn Type>>> {
-        let from = from.try_read().unwrap();
+        let from = from.re();
         let typ = Self::convert_str(&from.to_string())?;
         Ok(typ)
     }
@@ -200,7 +201,7 @@ impl Display for Types {
         let joined = self
             .types
             .iter()
-            .map(|t| t.try_read().unwrap().to_string())
+            .map(|t| t.re().to_string())
             .collect::<Vec<String>>()
             .join(", ");
         write!(f, "{}", joined)
@@ -217,11 +218,11 @@ impl<T: ParserDispatch> Parser<T> {
         operand: Arc<RwLock<OpOperand>>,
         typ: Arc<RwLock<dyn Type>>,
     ) -> Result<()> {
-        let operand = operand.try_read().unwrap();
+        let operand = operand.re();
         let operand_typ = operand.typ()?;
-        let operand_typ = operand_typ.try_read().unwrap();
+        let operand_typ = operand_typ.re();
         let token = self.previous().clone();
-        let typ = typ.try_read().unwrap();
+        let typ = typ.re();
         if operand_typ.to_string() != typ.to_string() {
             let msg = format!(
                 "Expected {} due to {}, but got {}",
@@ -269,16 +270,16 @@ impl<T: ParserDispatch> Parser<T> {
     /// ```
     pub fn parse_types_for_op_operands(&mut self, operands: OpOperands) -> Result<()> {
         let types = self.parse_types()?;
-        if types.len() != operands.vec().try_read().unwrap().len() {
+        if types.len() != operands.vec().re().len() {
             let msg = format!(
                 "Expected {} types but got {}",
-                operands.vec().try_read().unwrap().len(),
+                operands.vec().re().len(),
                 types.len()
             );
             return Err(anyhow::anyhow!(msg));
         }
         let operands = operands.vec();
-        let operands = operands.try_read().unwrap();
+        let operands = operands.re();
         for x in operands.iter().zip(types.iter()) {
             let (operand, typ) = x;
             self.verify_type(operand.clone(), typ.clone())?;

--- a/xrcf/src/ir/value.rs
+++ b/xrcf/src/ir/value.rs
@@ -690,8 +690,7 @@ impl IntoIterator for Values {
     type IntoIter = std::vec::IntoIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
-        let vec = self.values.rd();
-        vec.clone().into_iter()
+        self.values.rd().clone().into_iter()
     }
 }
 

--- a/xrcf/src/ir/value.rs
+++ b/xrcf/src/ir/value.rs
@@ -76,21 +76,15 @@ impl BlockArgument {
     ///
     /// Used during printing.
     pub fn new_name(&self) -> String {
-        let parent = self.parent();
-        let parent = parent.expect("no parent");
-        let arguments = parent.arguments();
-        let arguments = arguments.vec();
-        let arguments = arguments.rd();
+        let parent = self.parent().expect("no parent");
         let mut used_names = vec![];
-        for argument in arguments.iter() {
-            let argument = argument.rd();
-            if let Value::BlockArgument(argument) = &*argument {
+        for argument in parent.arguments().into_iter() {
+            if let Value::BlockArgument(argument) = &*argument.rd() {
                 if std::ptr::eq(self, argument) {
                     break;
                 }
             };
-            let name = argument.name();
-            if let Some(name) = name {
+            if let Some(name) = argument.name() {
                 used_names.push(name);
             }
         }

--- a/xrcf/src/ir/value.rs
+++ b/xrcf/src/ir/value.rs
@@ -61,8 +61,7 @@ impl BlockArgument {
         self.parent.clone()
     }
     pub fn set_name(&self, name: BlockArgumentName) {
-        let mut arg_name = self.name.wr();
-        *arg_name = name;
+        *self.name.wr() = name;
     }
     pub fn set_parent(&mut self, parent: Option<Arc<RwLock<Block>>>) {
         self.parent = parent;

--- a/xrcf/src/ir/value.rs
+++ b/xrcf/src/ir/value.rs
@@ -314,7 +314,7 @@ impl OpResult {
         let block_predecessors = block_predecessors.expect("expected predecessors");
         for predecessor in block_predecessors.iter() {
             let predecessor = predecessor.rd();
-            let names_in_block = predecessor.used_names_without_predecessors();
+            let names_in_block = predecessor.used_names();
             used_names.extend(names_in_block);
         }
 

--- a/xrcf/src/ir/value.rs
+++ b/xrcf/src/ir/value.rs
@@ -15,7 +15,7 @@ use crate::ir::VariableRenamer;
 use crate::parser::Parser;
 use crate::parser::ParserDispatch;
 use crate::parser::TokenKind;
-use crate::shared::RwLockExt;
+use crate::shared::SharedExt;
 use anyhow::Result;
 use std::fmt::Display;
 use std::sync::Arc;

--- a/xrcf/src/ir/value.rs
+++ b/xrcf/src/ir/value.rs
@@ -761,7 +761,7 @@ impl Values {
     /// Calling this on block arguments (like function arguments) will panic since
     /// block arguments do not specify a defining op.
     pub fn set_defining_op(&self, op: Arc<RwLock<dyn Op>>) {
-        let results = self.values.read().unwrap();
+        let results = self.values.re();
         for result in results.iter() {
             let mut mut_result = result.wr();
             match &mut *mut_result {

--- a/xrcf/src/lib.rs
+++ b/xrcf/src/lib.rs
@@ -43,6 +43,7 @@ pub mod convert;
 pub mod dialect;
 pub mod ir;
 pub mod parser;
+pub mod shared;
 pub mod targ3t;
 #[cfg(feature = "test-utils")]
 pub mod tester;

--- a/xrcf/src/parser/parser.rs
+++ b/xrcf/src/parser/parser.rs
@@ -178,7 +178,7 @@ enum Dialects {
 /// Assumes it is only called during the parsing of a block.
 fn replace_block_labels(block: Arc<RwLock<Block>>) {
     let label = block.label();
-    let label = label.try_read().unwrap();
+    let label = label.re();
     let label = match &*label {
         BlockName::Name(name) => name.clone(),
         BlockName::Unnamed => return,
@@ -188,17 +188,17 @@ fn replace_block_labels(block: Arc<RwLock<Block>>) {
     // Assumes the current block was not yet added to the parent region.
     let predecessors = parent.blocks();
     for predecessor in predecessors.into_iter() {
-        let predecessor = predecessor.try_read().unwrap();
+        let predecessor = predecessor.re();
         let ops = predecessor.ops();
-        let ops = ops.try_read().unwrap();
+        let ops = ops.re();
         for op in ops.iter() {
-            let op = op.try_read().unwrap();
+            let op = op.re();
             let operands = op.operation().operands().vec();
-            let operands = operands.try_read().unwrap();
+            let operands = operands.re();
             for operand in operands.iter() {
                 let mut operand = operand.wr();
                 let value = operand.value();
-                let value = value.try_read().unwrap();
+                let value = value.re();
                 if let Value::BlockLabel(current_label) = &*value {
                     if current_label.name() == label {
                         let block_ptr = BlockPtr::new(block.clone());
@@ -298,7 +298,7 @@ impl<T: ParserDispatch> Parser<T> {
         let block = Block::new(label, arguments.clone(), ops.clone(), parent);
         let block = Arc::new(RwLock::new(block));
         replace_block_labels(block.clone());
-        for argument in arguments.vec().try_read().unwrap().iter() {
+        for argument in arguments.vec().re().iter() {
             let mut argument = argument.wr();
             if let Value::BlockArgument(arg) = &mut *argument {
                 arg.set_parent(Some(block.clone()));
@@ -318,7 +318,7 @@ impl<T: ParserDispatch> Parser<T> {
             return Err(anyhow::anyhow!(msg));
         }
         let ops = block.ops();
-        let ops = ops.try_read().unwrap();
+        let ops = ops.re();
         for op in ops.iter() {
             op.operation().set_parent(Some(block.clone()));
         }

--- a/xrcf/src/parser/parser.rs
+++ b/xrcf/src/parser/parser.rs
@@ -309,7 +309,7 @@ impl<T: ParserDispatch> Parser<T> {
         while !self.is_region_end() && !self.is_block_definition() {
             let parent = Some(block.clone());
             let op = T::parse_op(self, parent)?;
-            let mut ops = ops.write().unwrap();
+            let mut ops = ops.wr();
             ops.push(op.clone());
         }
         if ops.re().is_empty() {

--- a/xrcf/src/parser/parser.rs
+++ b/xrcf/src/parser/parser.rs
@@ -312,7 +312,7 @@ impl<T: ParserDispatch> Parser<T> {
             let mut ops = ops.write().unwrap();
             ops.push(op.clone());
         }
-        if ops.read().unwrap().is_empty() {
+        if ops.re().is_empty() {
             let token = self.peek();
             let msg = self.error(&token, "Could not find operations in block");
             return Err(anyhow::anyhow!(msg));
@@ -388,7 +388,7 @@ impl<T: ParserDispatch> Parser<T> {
         };
         let op = T::parse_op(&mut parser, None)?;
         let opp = op.clone();
-        let opp = opp.read().unwrap();
+        let opp = opp.re();
         let casted = opp.as_any().downcast_ref::<ModuleOp>();
         let op: Arc<RwLock<dyn Op>> = if let Some(_module_op) = casted {
             op
@@ -409,7 +409,7 @@ impl<T: ParserDispatch> Parser<T> {
             let block = Block::new(label, arguments, ops.clone(), Some(module_region.clone()));
             let block = Arc::new(RwLock::new(block));
             {
-                let ops = ops.read().unwrap();
+                let ops = ops.re();
                 for child_op in ops.iter() {
                     child_op.operation().set_parent(Some(block.clone()));
                 }

--- a/xrcf/src/parser/parser.rs
+++ b/xrcf/src/parser/parser.rs
@@ -27,7 +27,7 @@ use crate::ir::Values;
 use crate::parser::scanner::Scanner;
 use crate::parser::token::Token;
 use crate::parser::token::TokenKind;
-use crate::shared::RwLockExt;
+use crate::shared::SharedExt;
 use anyhow::Result;
 use std::sync::Arc;
 use std::sync::RwLock;

--- a/xrcf/src/shared.rs
+++ b/xrcf/src/shared.rs
@@ -20,10 +20,15 @@ pub type Shared<T> = Arc<RwLock<T>>;
 
 /// A convenience trait around [RwLock].
 ///
-/// This trait makes using [RwLock] less verbose. Is this trait pretty? No. But
-/// in the end it's just a convenience trait that could easily be removed later.
-/// It does add some cognitive load for the read, but compared to
-/// `try_read().unwrap()` it saves a **lot** of typing.
+/// This trait makes using [RwLock] less verbose. It has two benefits. One is
+/// obviously that it saves a lot of typing. Another one is that one-liners are
+/// particularly powerful in Rust due to when variables are freed, see
+/// <https://xrcf.org/blog/iterators/> for more information.
+///
+/// Regarding the lost access to error handling (now it just always crashes),
+/// that's for now the default behavior until the project starts to support
+/// multithreading. Until that feature is introduced, any blocking should crash
+/// since it will hang anyway.
 ///
 /// # Example
 ///

--- a/xrcf/src/shared.rs
+++ b/xrcf/src/shared.rs
@@ -56,13 +56,13 @@ pub type Shared<T> = Arc<RwLock<T>>;
 /// ```
 pub trait SharedExt<T: ?Sized> {
     /// Convenience method for reading.
-    fn re(&self) -> RwLockReadGuard<T>;
+    fn rd(&self) -> RwLockReadGuard<T>;
     /// Convenience method for writing.
     fn wr(&self) -> RwLockWriteGuard<T>;
 }
 
 impl<T: ?Sized> SharedExt<T> for Shared<T> {
-    fn re(&self) -> RwLockReadGuard<T> {
+    fn rd(&self) -> RwLockReadGuard<T> {
         self.try_read().unwrap()
     }
     fn wr(&self) -> RwLockWriteGuard<T> {
@@ -74,5 +74,5 @@ impl<T: ?Sized> SharedExt<T> for Shared<T> {
 /// Just another test that runs even if the docstrings would not.
 fn test_shared() {
     let lock = Shared::new(42.into());
-    assert_eq!(*lock.re(), 42);
+    assert_eq!(*lock.rd(), 42);
 }

--- a/xrcf/src/shared.rs
+++ b/xrcf/src/shared.rs
@@ -1,0 +1,93 @@
+use std::ops::Deref;
+use std::sync::Arc;
+use std::sync::RwLock;
+use std::sync::RwLockReadGuard;
+use std::sync::RwLockWriteGuard;
+
+struct SharedGuard<T> {
+    inner: Arc<RwLock<T>>,
+}
+
+impl<T> SharedGuard<T> {
+    fn new(inner: T) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(inner)),
+        }
+    }
+    fn read(&self) -> RwLockReadGuard<T> {
+        self.inner.try_read().unwrap()
+    }
+    fn write(&self) -> RwLockWriteGuard<T> {
+        self.inner.try_write().unwrap()
+    }
+    fn try_read(&self) -> RwLockReadGuard<T> {
+        self.inner.try_read().unwrap()
+    }
+    fn try_write(&self) -> RwLockWriteGuard<T> {
+        self.inner.try_write().unwrap()
+    }
+}
+
+pub struct ReadRef<'a, T> {
+    guard: RwLockReadGuard<'a, T>,
+}
+
+impl<'a, T> Deref for ReadRef<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        &self.guard
+    }
+}
+
+/// A shared object that can be read and written to.
+///
+/// Compared to `Arc<RwLock<T>>`, this API slightly less verbose.
+///
+/// # Example
+///
+/// ```
+/// use xrcf::ir::Region;
+/// use xrcf::shared::Shared;
+///
+/// let region = Region::default();
+/// let _ = region.add_empty_block();
+/// let shared = Shared::new(region);
+/// assert_eq!(shared.read().blocks().into_iter().len(), 1);
+/// ```
+/// And the same now using `Arc<RwLock<T>>`:
+/// ```
+/// use std::sync::{Arc, RwLock};
+/// use xrcf::ir::Region;
+///
+/// let region = Region::default();
+/// let _unset_block = region.add_empty_block();
+/// let shared = Arc::new(RwLock::new(region));
+/// assert_eq!(shared.try_read().unwrap().blocks().into_iter().len(), 1);
+/// ```
+pub struct Shared<T> {
+    inner: SharedGuard<T>,
+}
+
+impl<T> Shared<T> {
+    pub fn new(inner: T) -> Self {
+        Self {
+            inner: SharedGuard::new(inner),
+        }
+    }
+    pub fn read(&self) -> ReadRef<T> {
+        ReadRef {
+            guard: self.inner.read(),
+        }
+    }
+    pub fn write(&self) -> RwLockWriteGuard<T> {
+        self.inner.write()
+    }
+    pub fn try_read(&self) -> ReadRef<T> {
+        ReadRef {
+            guard: self.inner.try_read(),
+        }
+    }
+    pub fn try_write(&self) -> RwLockWriteGuard<T> {
+        self.inner.try_write()
+    }
+}

--- a/xrcf/src/shared.rs
+++ b/xrcf/src/shared.rs
@@ -45,7 +45,7 @@ impl<T> SharedExt<T> for Shared<T> {
 /// use xrcf::shared::RwLockExt;
 ///
 /// let lock = Arc::new(RwLock::new(42));
-/// assert_eq!(*lock.rd(), 42);
+/// assert_eq!(*lock.re(), 42);
 /// ```
 /// and with `Shared`:
 /// ```
@@ -55,7 +55,7 @@ impl<T> SharedExt<T> for Shared<T> {
 /// use xrcf::shared::Shared;
 ///
 /// let lock = Shared::new(42.into());
-/// assert_eq!(*lock.rd(), 42);
+/// assert_eq!(*lock.re(), 42);
 /// ```
 /// Without this trait:
 /// ```
@@ -67,13 +67,13 @@ impl<T> SharedExt<T> for Shared<T> {
 /// ```
 pub trait RwLockExt<T> {
     /// Convenience method for reading.
-    fn rd(&self) -> RwLockReadGuard<T>;
+    fn re(&self) -> RwLockReadGuard<T>;
     /// Convenience method for writing.
     fn wr(&self) -> RwLockWriteGuard<T>;
 }
 
 impl<T> RwLockExt<T> for Arc<RwLock<T>> {
-    fn rd(&self) -> RwLockReadGuard<T> {
+    fn re(&self) -> RwLockReadGuard<T> {
         self.try_read().unwrap()
     }
     fn wr(&self) -> RwLockWriteGuard<T> {
@@ -85,5 +85,5 @@ impl<T> RwLockExt<T> for Arc<RwLock<T>> {
 /// Just another test that runs even if the docstrings don't.
 fn test_shared() {
     let lock = Shared::new(42.into());
-    assert_eq!(*lock.rd(), 42);
+    assert_eq!(*lock.re(), 42);
 }

--- a/xrcf/src/shared.rs
+++ b/xrcf/src/shared.rs
@@ -54,14 +54,14 @@ pub type Shared<T> = Arc<RwLock<T>>;
 /// let lock = Arc::new(RwLock::new(42));
 /// assert_eq!(*lock.try_read().unwrap(), 42);
 /// ```
-pub trait SharedExt<T> {
+pub trait SharedExt<T: ?Sized> {
     /// Convenience method for reading.
     fn re(&self) -> RwLockReadGuard<T>;
     /// Convenience method for writing.
     fn wr(&self) -> RwLockWriteGuard<T>;
 }
 
-impl<T> SharedExt<T> for Arc<RwLock<T>> {
+impl<T: ?Sized> SharedExt<T> for Shared<T> {
     fn re(&self) -> RwLockReadGuard<T> {
         self.try_read().unwrap()
     }

--- a/xrcf/src/shared.rs
+++ b/xrcf/src/shared.rs
@@ -18,17 +18,6 @@ use std::sync::RwLockWriteGuard;
 /// can also be used together with [SharedExt].
 pub type Shared<T> = Arc<RwLock<T>>;
 
-/// A trait for creating new Arc<RwLock<T>> values
-pub trait SharedExt<T> {
-    fn new(value: T) -> Self;
-}
-
-impl<T> SharedExt<T> for Shared<T> {
-    fn new(value: T) -> Self {
-        Arc::new(RwLock::new(value))
-    }
-}
-
 /// A convenience trait for the `RwLock` API.
 ///
 /// This trait makes using [RwLock] less verbose. Is this trait pretty? No. But

--- a/xrcf/src/shared.rs
+++ b/xrcf/src/shared.rs
@@ -15,16 +15,7 @@ use std::sync::RwLockWriteGuard;
 /// let lock = Shared::new(42.into());
 /// assert_eq!(*lock.try_read().unwrap(), 42);
 /// ```
-/// can also be used together with [SharedExt]:
-/// ```
-/// use std::sync::Arc;
-/// use std::sync::RwLock;
-/// use xrcf::shared::Shared;
-/// use xrcf::shared::SharedExt;
-///
-/// let lock = Shared::new(42.into());
-/// assert_eq!(*lock.rd(), 42);
-/// ```
+/// can also be used together with [SharedExt].
 pub type Shared<T> = Arc<RwLock<T>>;
 
 /// A trait for creating new Arc<RwLock<T>> values

--- a/xrcf/src/shared.rs
+++ b/xrcf/src/shared.rs
@@ -33,7 +33,7 @@ pub type Shared<T> = Arc<RwLock<T>>;
 /// use std::sync::RwLock;
 /// use xrcf::shared::SharedExt;
 ///
-/// let lock = Shared::new(42));
+/// let lock = Arc::new(RwLock::new(42));
 /// assert_eq!(*lock.re(), 42);
 /// ```
 /// and with `Shared`:
@@ -51,7 +51,7 @@ pub type Shared<T> = Arc<RwLock<T>>;
 /// use std::sync::Arc;
 /// use std::sync::RwLock;
 ///
-/// let lock = Shared::new(42));
+/// let lock = Arc::new(RwLock::new(42));
 /// assert_eq!(*lock.try_read().unwrap(), 42);
 /// ```
 pub trait SharedExt<T: ?Sized> {

--- a/xrcf/src/shared.rs
+++ b/xrcf/src/shared.rs
@@ -3,7 +3,7 @@ use std::sync::RwLock;
 use std::sync::RwLockReadGuard;
 use std::sync::RwLockWriteGuard;
 
-/// A convenience type alias for [Arc<RwLock<T>>].
+/// A convenience type alias for `Arc<RwLock<T>>`.
 ///
 /// # Example
 ///

--- a/xrcf/src/shared.rs
+++ b/xrcf/src/shared.rs
@@ -31,7 +31,7 @@ pub type Shared<T> = Arc<RwLock<T>>;
 /// ```
 /// use std::sync::Arc;
 /// use std::sync::RwLock;
-/// use xrcf::shared::RwLockExt;
+/// use xrcf::shared::SharedExt;
 ///
 /// let lock = Arc::new(RwLock::new(42));
 /// assert_eq!(*lock.re(), 42);
@@ -40,8 +40,8 @@ pub type Shared<T> = Arc<RwLock<T>>;
 /// ```
 /// use std::sync::Arc;
 /// use std::sync::RwLock;
-/// use xrcf::shared::RwLockExt;
 /// use xrcf::shared::Shared;
+/// use xrcf::shared::SharedExt;
 ///
 /// let lock = Shared::new(42.into());
 /// assert_eq!(*lock.re(), 42);
@@ -54,14 +54,14 @@ pub type Shared<T> = Arc<RwLock<T>>;
 /// let lock = Arc::new(RwLock::new(42));
 /// assert_eq!(*lock.try_read().unwrap(), 42);
 /// ```
-pub trait RwLockExt<T> {
+pub trait SharedExt<T> {
     /// Convenience method for reading.
     fn re(&self) -> RwLockReadGuard<T>;
     /// Convenience method for writing.
     fn wr(&self) -> RwLockWriteGuard<T>;
 }
 
-impl<T> RwLockExt<T> for Arc<RwLock<T>> {
+impl<T> SharedExt<T> for Arc<RwLock<T>> {
     fn re(&self) -> RwLockReadGuard<T> {
         self.try_read().unwrap()
     }

--- a/xrcf/src/shared.rs
+++ b/xrcf/src/shared.rs
@@ -29,12 +29,6 @@ impl<T> SharedExt<T> for Shared<T> {
     }
 }
 
-#[test]
-fn test_shared() {
-    let lock = Shared::new(42.into());
-    assert_eq!(*lock.try_read().unwrap(), 42);
-}
-
 /// A convenience trait for the `RwLock` API.
 ///
 /// This trait makes using [RwLock] less verbose. Is this trait pretty? No. But
@@ -85,4 +79,11 @@ impl<T> RwLockExt<T> for Arc<RwLock<T>> {
     fn wr(&self) -> RwLockWriteGuard<T> {
         self.try_write().unwrap()
     }
+}
+
+#[test]
+/// Just another test that runs even if the docstrings don't.
+fn test_shared() {
+    let lock = Shared::new(42.into());
+    assert_eq!(*lock.rd(), 42);
 }

--- a/xrcf/src/shared.rs
+++ b/xrcf/src/shared.rs
@@ -3,75 +3,95 @@ use std::sync::RwLock;
 use std::sync::RwLockReadGuard;
 use std::sync::RwLockWriteGuard;
 
-struct SharedGuard<T> {
-    inner: Arc<RwLock<T>>,
-}
-
-impl<T> SharedGuard<T> {
-    fn new(inner: T) -> Self {
-        Self {
-            inner: Arc::new(RwLock::new(inner)),
-        }
-    }
-    fn read(&self) -> RwLockReadGuard<T> {
-        self.inner.try_read().unwrap()
-    }
-    fn write(&self) -> RwLockWriteGuard<T> {
-        self.inner.try_write().unwrap()
-    }
-    fn try_read(&self) -> RwLockReadGuard<T> {
-        self.inner.try_read().unwrap()
-    }
-    fn try_write(&self) -> RwLockWriteGuard<T> {
-        self.inner.try_write().unwrap()
-    }
-}
-
-/// A shared object that can be read and written to.
-///
-/// Compared to `Arc<RwLock<T>>`, this API slightly less verbose.
+/// A convenience type alias for [Arc<RwLock<T>>].
 ///
 /// # Example
 ///
 /// ```
-/// use xrcf::ir::Region;
+/// use std::sync::Arc;
+/// use std::sync::RwLock;
 /// use xrcf::shared::Shared;
 ///
-/// let region = Region::default();
-/// let _ = region.add_empty_block();
-/// let shared = Shared::new(region);
-/// assert_eq!(shared.read().blocks().into_iter().len(), 1);
+/// let lock = Shared::new(42.into());
+/// assert_eq!(*lock.try_read().unwrap(), 42);
 /// ```
-/// And the same now using `Arc<RwLock<T>>`:
+/// can also be used together with [SharedExt]:
 /// ```
-/// use std::sync::{Arc, RwLock};
-/// use xrcf::ir::Region;
+/// use std::sync::Arc;
+/// use std::sync::RwLock;
+/// use xrcf::shared::Shared;
+/// use xrcf::shared::SharedExt;
 ///
-/// let region = Region::default();
-/// let _unset_block = region.add_empty_block();
-/// let shared = Arc::new(RwLock::new(region));
-/// assert_eq!(shared.try_read().unwrap().blocks().into_iter().len(), 1);
+/// let lock = Shared::new(42.into());
+/// assert_eq!(*lock.rd(), 42);
 /// ```
-pub struct Shared<T> {
-    inner: SharedGuard<T>,
+pub type Shared<T> = Arc<RwLock<T>>;
+
+/// A trait for creating new Arc<RwLock<T>> values
+pub trait SharedExt<T> {
+    fn new(value: T) -> Self;
 }
 
-impl<T> Shared<T> {
-    pub fn new(inner: T) -> Self {
-        Self {
-            inner: SharedGuard::new(inner),
-        }
+impl<T> SharedExt<T> for Shared<T> {
+    fn new(value: T) -> Self {
+        Arc::new(RwLock::new(value))
     }
-    pub fn read(&self) -> RwLockReadGuard<T> {
-        self.inner.read()
+}
+
+#[test]
+fn test_shared() {
+    let lock = Shared::new(42.into());
+    assert_eq!(*lock.try_read().unwrap(), 42);
+}
+
+/// A convenience trait for the `RwLock` API.
+///
+/// This trait makes using [RwLock] less verbose. Is this trait pretty? No. But
+/// in the end it's just a convenience trait that could easily be removed later.
+/// It does add some cognitive load for the read, but compared to
+/// `try_read().unwrap()` it saves a **lot** of typing.
+///
+/// # Example
+///
+/// With this trait:
+/// ```
+/// use std::sync::Arc;
+/// use std::sync::RwLock;
+/// use xrcf::shared::RwLockExt;
+///
+/// let lock = Arc::new(RwLock::new(42));
+/// assert_eq!(*lock.rd(), 42);
+/// ```
+/// and with `Shared`:
+/// ```
+/// use std::sync::Arc;
+/// use std::sync::RwLock;
+/// use xrcf::shared::RwLockExt;
+/// use xrcf::shared::Shared;
+///
+/// let lock = Shared::new(42.into());
+/// assert_eq!(*lock.rd(), 42);
+/// ```
+/// Without this trait:
+/// ```
+/// use std::sync::Arc;
+/// use std::sync::RwLock;
+///
+/// let lock = Arc::new(RwLock::new(42));
+/// assert_eq!(*lock.try_read().unwrap(), 42);
+/// ```
+pub trait RwLockExt<T> {
+    /// Convenience method for reading.
+    fn rd(&self) -> RwLockReadGuard<T>;
+    /// Convenience method for writing.
+    fn wr(&self) -> RwLockWriteGuard<T>;
+}
+
+impl<T> RwLockExt<T> for Arc<RwLock<T>> {
+    fn rd(&self) -> RwLockReadGuard<T> {
+        self.try_read().unwrap()
     }
-    pub fn write(&self) -> RwLockWriteGuard<T> {
-        self.inner.write()
-    }
-    pub fn try_read(&self) -> RwLockReadGuard<T> {
-        self.inner.try_read()
-    }
-    pub fn try_write(&self) -> RwLockWriteGuard<T> {
-        self.inner.try_write()
+    fn wr(&self) -> RwLockWriteGuard<T> {
+        self.try_write().unwrap()
     }
 }

--- a/xrcf/src/shared.rs
+++ b/xrcf/src/shared.rs
@@ -18,7 +18,7 @@ use std::sync::RwLockWriteGuard;
 /// can also be used together with [SharedExt].
 pub type Shared<T> = Arc<RwLock<T>>;
 
-/// A convenience trait for the `RwLock` API.
+/// A convenience trait around [RwLock].
 ///
 /// This trait makes using [RwLock] less verbose. Is this trait pretty? No. But
 /// in the end it's just a convenience trait that could easily be removed later.
@@ -71,7 +71,7 @@ impl<T: ?Sized> SharedExt<T> for Shared<T> {
 }
 
 #[test]
-/// Just another test that runs even if the docstrings don't.
+/// Just another test that runs even if the docstrings would not.
 fn test_shared() {
     let lock = Shared::new(42.into());
     assert_eq!(*lock.re(), 42);

--- a/xrcf/src/shared.rs
+++ b/xrcf/src/shared.rs
@@ -33,7 +33,7 @@ pub type Shared<T> = Arc<RwLock<T>>;
 /// use std::sync::RwLock;
 /// use xrcf::shared::SharedExt;
 ///
-/// let lock = Arc::new(RwLock::new(42));
+/// let lock = Shared::new(42));
 /// assert_eq!(*lock.re(), 42);
 /// ```
 /// and with `Shared`:
@@ -51,7 +51,7 @@ pub type Shared<T> = Arc<RwLock<T>>;
 /// use std::sync::Arc;
 /// use std::sync::RwLock;
 ///
-/// let lock = Arc::new(RwLock::new(42));
+/// let lock = Shared::new(42));
 /// assert_eq!(*lock.try_read().unwrap(), 42);
 /// ```
 pub trait SharedExt<T: ?Sized> {

--- a/xrcf/src/shared.rs
+++ b/xrcf/src/shared.rs
@@ -1,4 +1,3 @@
-use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::RwLock;
 use std::sync::RwLockReadGuard;
@@ -25,17 +24,6 @@ impl<T> SharedGuard<T> {
     }
     fn try_write(&self) -> RwLockWriteGuard<T> {
         self.inner.try_write().unwrap()
-    }
-}
-
-pub struct ReadRef<'a, T> {
-    guard: RwLockReadGuard<'a, T>,
-}
-
-impl<'a, T> Deref for ReadRef<'a, T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.guard
     }
 }
 
@@ -74,18 +62,14 @@ impl<T> Shared<T> {
             inner: SharedGuard::new(inner),
         }
     }
-    pub fn read(&self) -> ReadRef<T> {
-        ReadRef {
-            guard: self.inner.read(),
-        }
+    pub fn read(&self) -> RwLockReadGuard<T> {
+        self.inner.read()
     }
     pub fn write(&self) -> RwLockWriteGuard<T> {
         self.inner.write()
     }
-    pub fn try_read(&self) -> ReadRef<T> {
-        ReadRef {
-            guard: self.inner.try_read(),
-        }
+    pub fn try_read(&self) -> RwLockReadGuard<T> {
+        self.inner.try_read()
     }
     pub fn try_write(&self) -> RwLockWriteGuard<T> {
         self.inner.try_write()

--- a/xrcf/src/shared.rs
+++ b/xrcf/src/shared.rs
@@ -34,7 +34,7 @@ pub type Shared<T> = Arc<RwLock<T>>;
 /// use xrcf::shared::SharedExt;
 ///
 /// let lock = Arc::new(RwLock::new(42));
-/// assert_eq!(*lock.re(), 42);
+/// assert_eq!(*lock.rd(), 42);
 /// ```
 /// and with `Shared`:
 /// ```
@@ -44,7 +44,7 @@ pub type Shared<T> = Arc<RwLock<T>>;
 /// use xrcf::shared::SharedExt;
 ///
 /// let lock = Shared::new(42.into());
-/// assert_eq!(*lock.re(), 42);
+/// assert_eq!(*lock.rd(), 42);
 /// ```
 /// Without this trait:
 /// ```

--- a/xrcf/src/targ3t/llvmir/typ.rs
+++ b/xrcf/src/targ3t/llvmir/typ.rs
@@ -21,7 +21,7 @@ impl ArrayType {
 
 impl Type for ArrayType {
     fn display(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let element_type = self.element_type.re();
+        let element_type = self.element_type.rd();
         write!(f, "[{} x {}]", self.num_elements, element_type)
     }
     fn as_any(&self) -> &dyn std::any::Any {

--- a/xrcf/src/targ3t/llvmir/typ.rs
+++ b/xrcf/src/targ3t/llvmir/typ.rs
@@ -1,5 +1,6 @@
 use crate::ir::Type;
 use crate::ir::Types;
+use crate::shared::SharedExt;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::sync::Arc;
@@ -20,7 +21,7 @@ impl ArrayType {
 
 impl Type for ArrayType {
     fn display(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let element_type = self.element_type.read().unwrap();
+        let element_type = self.element_type.re();
         write!(f, "[{} x {}]", self.num_elements, element_type)
     }
     fn as_any(&self) -> &dyn std::any::Any {

--- a/xrcf/src/targ3t/llvmir/typ.rs
+++ b/xrcf/src/targ3t/llvmir/typ.rs
@@ -21,8 +21,7 @@ impl ArrayType {
 
 impl Type for ArrayType {
     fn display(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let element_type = self.element_type.rd();
-        write!(f, "[{} x {}]", self.num_elements, element_type)
+        write!(f, "[{} x {}]", self.num_elements, self.element_type.rd())
     }
     fn as_any(&self) -> &dyn std::any::Any {
         self

--- a/xrcf/src/tester.rs
+++ b/xrcf/src/tester.rs
@@ -107,7 +107,7 @@ impl Tester {
         Self::print_heading("Before parse", src);
         let module = Parser::<DefaultParserDispatch>::parse(&src).unwrap();
         let read_module = module.clone();
-        let read_module = read_module.re();
+        let read_module = read_module.rd();
         let actual = format!("{}", read_module);
         Self::print_heading("After parse", &actual);
         (module, actual)
@@ -132,13 +132,13 @@ impl Tester {
                 panic!("Expected changes");
             }
         };
-        let actual = format!("{}", new_root_op.re());
+        let actual = format!("{}", new_root_op.rd());
         let msg = format!("After (transform {arguments:?})");
         Self::print_heading(&msg, &actual);
         (new_root_op, actual)
     }
     fn verify_core(op: Arc<RwLock<dyn Op>>) {
-        let op = op.re();
+        let op = op.rd();
         if !op.name().to_string().contains("module") {
             let parent = op.operation().parent();
             assert!(
@@ -148,13 +148,13 @@ impl Tester {
             );
             let parent = parent.unwrap();
             let operation = op.operation();
-            let operation = operation.re();
+            let operation = operation.rd();
             assert!(parent.index_of(&operation).is_some(),
             "Could not find the following op in parent. Is the parent field pointing to the wrong block?\n{}",
             op);
             let results = op.operation().results();
-            for result in results.vec().re().iter() {
-                let value = result.re();
+            for result in results.vec().rd().iter() {
+                let value = result.rd();
                 assert!(value.typ().is_ok(), "type was not set for {value}");
             }
         }

--- a/xrcf/src/tester.rs
+++ b/xrcf/src/tester.rs
@@ -50,8 +50,7 @@ impl Tester {
         let expected = expected.trim();
         let l = max(actual.lines().count(), expected.lines().count());
         for i in 0..l {
-            let actual_line = actual.lines().nth(i);
-            let actual_line = match actual_line {
+            let actual_line = match actual.lines().nth(i) {
                 None => {
                     panic!(
                         "Expected line {i} not found in output: called from {}",
@@ -60,8 +59,7 @@ impl Tester {
                 }
                 Some(actual_line) => actual_line,
             };
-            let expected_line = expected.lines().nth(i);
-            let expected_line = match expected_line {
+            let expected_line = match expected.lines().nth(i) {
                 None => {
                     panic!(
                         "Expected line {i} not found in output: called from {}",
@@ -103,12 +101,9 @@ impl Tester {
         info!("{msg}:\n```\n{src}\n```\n");
     }
     pub fn parse(src: &str) -> (Arc<RwLock<dyn Op>>, String) {
-        let src = src.trim();
-        Self::print_heading("Before parse", src);
+        Self::print_heading("Before parse", src.trim());
         let module = Parser::<DefaultParserDispatch>::parse(&src).unwrap();
-        let read_module = module.clone();
-        let read_module = read_module.rd();
-        let actual = format!("{}", read_module);
+        let actual = format!("{}", module.rd());
         Self::print_heading("After parse", &actual);
         (module, actual)
     }
@@ -152,8 +147,7 @@ impl Tester {
             assert!(parent.index_of(&operation).is_some(),
             "Could not find the following op in parent. Is the parent field pointing to the wrong block?\n{}",
             op);
-            let results = op.operation().results();
-            for result in results.vec().rd().iter() {
+            for result in operation.results().vec().rd().iter() {
                 let value = result.rd();
                 assert!(value.typ().is_ok(), "type was not set for {value}");
             }

--- a/xrcf/src/transform.rs
+++ b/xrcf/src/transform.rs
@@ -230,10 +230,10 @@ pub fn transform<T: TransformDispatch>(
     let mut result = RewriteResult::Unchanged;
     for pass in options.passes().vec() {
         if options.print_ir_before_all() {
+            let op = op.rd();
             writeln!(
                 &mut *options.writer.wr(),
-                "// ----- // IR Dump before {pass} //----- //\n{}\n\n",
-                op.rd()
+                "// ----- // IR Dump before {pass} //----- //\n{op}\n\n",
             )?;
         }
         let new_result = T::dispatch(op.clone(), pass)?;

--- a/xrcf/src/transform.rs
+++ b/xrcf/src/transform.rs
@@ -233,7 +233,7 @@ pub fn transform<T: TransformDispatch>(
             writeln!(
                 &mut *options.writer.wr(),
                 "// ----- // IR Dump before {pass} //----- //\n{}\n\n",
-                op.re()
+                op.rd()
             )?;
         }
         let new_result = T::dispatch(op.clone(), pass)?;

--- a/xrcf/src/transform.rs
+++ b/xrcf/src/transform.rs
@@ -7,6 +7,7 @@ use crate::convert::ConvertSCFToCF;
 use crate::convert::Pass;
 use crate::convert::RewriteResult;
 use crate::ir::Op;
+use crate::shared::Shared;
 use crate::shared::SharedExt;
 use anyhow::Result;
 use clap::Arg;
@@ -119,14 +120,14 @@ impl TransformOptions {
         TransformOptions {
             passes,
             print_ir_before_all,
-            writer: Arc::new(RwLock::new(std::io::stderr())),
+            writer: Shared::new(std::io::stderr().into()),
         }
     }
     pub fn from_passes(passes: Passes) -> TransformOptions {
         TransformOptions {
             passes,
             print_ir_before_all: false,
-            writer: Arc::new(RwLock::new(std::io::stderr())),
+            writer: Shared::new(std::io::stderr().into()),
         }
     }
     pub fn print_ir_before_all(&self) -> bool {

--- a/xrcf/src/transform.rs
+++ b/xrcf/src/transform.rs
@@ -7,6 +7,7 @@ use crate::convert::ConvertSCFToCF;
 use crate::convert::Pass;
 use crate::convert::RewriteResult;
 use crate::ir::Op;
+use crate::shared::SharedExt;
 use anyhow::Result;
 use clap::Arg;
 use clap::ArgAction;
@@ -231,7 +232,7 @@ pub fn transform<T: TransformDispatch>(
             writeln!(
                 &mut *options.writer.write().unwrap(),
                 "// ----- // IR Dump before {pass} //----- //\n{}\n\n",
-                op.try_read().unwrap()
+                op.re()
             )?;
         }
         let new_result = T::dispatch(op.clone(), pass)?;

--- a/xrcf/src/transform.rs
+++ b/xrcf/src/transform.rs
@@ -230,7 +230,7 @@ pub fn transform<T: TransformDispatch>(
     for pass in options.passes().vec() {
         if options.print_ir_before_all() {
             writeln!(
-                &mut *options.writer.write().unwrap(),
+                &mut *options.writer.wr(),
                 "// ----- // IR Dump before {pass} //----- //\n{}\n\n",
                 op.re()
             )?;

--- a/xrcf/tests/arith.rs
+++ b/xrcf/tests/arith.rs
@@ -49,25 +49,25 @@ fn parse_addi() {
     let (module, actual) = Tester::parse(src);
     Tester::verify(module.clone());
 
-    let module = module.re();
-    let module_operation = module.operation().re();
+    let module = module.rd();
+    let module_operation = module.operation().rd();
     let module_parent = module_operation.parent();
     assert!(module_parent.is_none());
 
     let ops = module.ops();
     assert_eq!(ops.len(), 1);
-    let func_op = ops[0].re();
-    let func_operation = func_op.operation().re();
+    let func_op = ops[0].rd();
+    let func_operation = func_op.operation().rd();
     assert_eq!(func_operation.name(), FuncOp::operation_name());
     let func_parent = func_operation.parent();
     assert!(func_parent.is_some());
 
     let func_op = ops[0].clone();
-    let func_op = func_op.re();
+    let func_op = func_op.rd();
     let func_parent = func_op.parent_op();
     assert!(func_parent.is_some());
     let func_parent = func_parent.unwrap();
-    let func_parent = func_parent.re();
+    let func_parent = func_parent.rd();
     assert_eq!(func_parent.name().to_string(), "module");
 
     Tester::check_lines_contain(&actual, expected, caller);

--- a/xrcf/tests/arith.rs
+++ b/xrcf/tests/arith.rs
@@ -4,6 +4,7 @@ use indoc::indoc;
 use std::panic::Location;
 use xrcf::dialect::func::FuncOp;
 use xrcf::ir::Op;
+use xrcf::shared::SharedExt;
 use xrcf::tester::Tester;
 
 #[test]
@@ -48,25 +49,25 @@ fn parse_addi() {
     let (module, actual) = Tester::parse(src);
     Tester::verify(module.clone());
 
-    let module = module.try_read().unwrap();
-    let module_operation = module.operation().try_read().unwrap();
+    let module = module.re();
+    let module_operation = module.operation().re();
     let module_parent = module_operation.parent();
     assert!(module_parent.is_none());
 
     let ops = module.ops();
     assert_eq!(ops.len(), 1);
-    let func_op = ops[0].try_read().unwrap();
-    let func_operation = func_op.operation().try_read().unwrap();
+    let func_op = ops[0].re();
+    let func_operation = func_op.operation().re();
     assert_eq!(func_operation.name(), FuncOp::operation_name());
     let func_parent = func_operation.parent();
     assert!(func_parent.is_some());
 
     let func_op = ops[0].clone();
-    let func_op = func_op.try_read().unwrap();
+    let func_op = func_op.re();
     let func_parent = func_op.parent_op();
     assert!(func_parent.is_some());
     let func_parent = func_parent.unwrap();
-    let func_parent = func_parent.try_read().unwrap();
+    let func_parent = func_parent.re();
     assert_eq!(func_parent.name().to_string(), "module");
 
     Tester::check_lines_contain(&actual, expected, caller);

--- a/xrcf/tests/arith.rs
+++ b/xrcf/tests/arith.rs
@@ -49,12 +49,9 @@ fn parse_addi() {
     let (module, actual) = Tester::parse(src);
     Tester::verify(module.clone());
 
-    let module = module.rd();
-    let module_operation = module.operation().rd();
-    let module_parent = module_operation.parent();
-    assert!(module_parent.is_none());
+    assert!(module.rd().operation().rd().parent().is_none());
 
-    let ops = module.ops();
+    let ops = module.rd().ops();
     assert_eq!(ops.len(), 1);
     let func_op = ops[0].rd();
     let func_operation = func_op.operation().rd();

--- a/xrcf/tests/canonicalize.rs
+++ b/xrcf/tests/canonicalize.rs
@@ -36,15 +36,11 @@ fn determine_users() {
 
     let op0 = ops[0].rd();
     let op0 = op0.as_any().downcast_ref::<arith::ConstantOp>().unwrap();
-    let operation = op0.operation().rd();
-    let users = operation.users();
-    assert_eq!(users.len(), 0);
+    assert_eq!(op0.operation().rd().users().len(), 0);
 
     let op1 = ops[1].rd();
     let op1 = op1.as_any().downcast_ref::<arith::ConstantOp>().unwrap();
-    let operation = op1.operation().rd();
-    let users = operation.users();
-    assert_eq!(users.len(), 1);
+    assert_eq!(op1.operation().rd().users().len(), 1);
 }
 
 #[test]

--- a/xrcf/tests/canonicalize.rs
+++ b/xrcf/tests/canonicalize.rs
@@ -26,23 +26,23 @@ fn determine_users() {
 
     let module = Parser::<DefaultParserDispatch>::parse(src).unwrap();
     Tester::verify(module.clone());
-    let module = module.re();
+    let module = module.rd();
 
     let ops = module.ops();
     assert_eq!(ops.len(), 1);
-    let func_op = ops[0].re();
+    let func_op = ops[0].rd();
     let ops = func_op.ops();
     assert_eq!(ops.len(), 3);
 
-    let op0 = ops[0].re();
+    let op0 = ops[0].rd();
     let op0 = op0.as_any().downcast_ref::<arith::ConstantOp>().unwrap();
-    let operation = op0.operation().re();
+    let operation = op0.operation().rd();
     let users = operation.users();
     assert_eq!(users.len(), 0);
 
-    let op1 = ops[1].re();
+    let op1 = ops[1].rd();
     let op1 = op1.as_any().downcast_ref::<arith::ConstantOp>().unwrap();
-    let operation = op1.operation().re();
+    let operation = op1.operation().rd();
     let users = operation.users();
     assert_eq!(users.len(), 1);
 }
@@ -70,7 +70,7 @@ fn canonicalize_addi() {
     Tester::init_tracing();
     let (module, actual) = Tester::transform(flags(), src);
     Tester::verify(module.clone());
-    let module = module.re();
+    let module = module.rd();
     Tester::check_lines_exact(&actual, expected, Location::caller());
     assert!(module.as_any().is::<ir::ModuleOp>());
 }

--- a/xrcf/tests/canonicalize.rs
+++ b/xrcf/tests/canonicalize.rs
@@ -7,6 +7,7 @@ use xrcf::ir;
 use xrcf::ir::Op;
 use xrcf::parser::DefaultParserDispatch;
 use xrcf::parser::Parser;
+use xrcf::shared::SharedExt;
 use xrcf::tester::Tester;
 
 fn flags() -> Vec<&'static str> {
@@ -25,23 +26,23 @@ fn determine_users() {
 
     let module = Parser::<DefaultParserDispatch>::parse(src).unwrap();
     Tester::verify(module.clone());
-    let module = module.try_read().unwrap();
+    let module = module.re();
 
     let ops = module.ops();
     assert_eq!(ops.len(), 1);
-    let func_op = ops[0].try_read().unwrap();
+    let func_op = ops[0].re();
     let ops = func_op.ops();
     assert_eq!(ops.len(), 3);
 
-    let op0 = ops[0].try_read().unwrap();
+    let op0 = ops[0].re();
     let op0 = op0.as_any().downcast_ref::<arith::ConstantOp>().unwrap();
-    let operation = op0.operation().try_read().unwrap();
+    let operation = op0.operation().re();
     let users = operation.users();
     assert_eq!(users.len(), 0);
 
-    let op1 = ops[1].try_read().unwrap();
+    let op1 = ops[1].re();
     let op1 = op1.as_any().downcast_ref::<arith::ConstantOp>().unwrap();
-    let operation = op1.operation().try_read().unwrap();
+    let operation = op1.operation().re();
     let users = operation.users();
     assert_eq!(users.len(), 1);
 }
@@ -69,7 +70,7 @@ fn canonicalize_addi() {
     Tester::init_tracing();
     let (module, actual) = Tester::transform(flags(), src);
     Tester::verify(module.clone());
-    let module = module.try_read().unwrap();
+    let module = module.re();
     Tester::check_lines_exact(&actual, expected, Location::caller());
     assert!(module.as_any().is::<ir::ModuleOp>());
 }

--- a/xrcf/tests/convert/experimental_to_mlir.rs
+++ b/xrcf/tests/convert/experimental_to_mlir.rs
@@ -38,7 +38,7 @@ fn test_constant() {
     let caller = Location::caller();
     let (module, actual) = Tester::transform(flags(), src);
     Tester::verify(module.clone());
-    let module = module.re();
+    let module = module.rd();
     assert!(module.as_any().is::<ModuleOp>());
     Tester::check_lines_contain(&actual, expected, caller);
 }

--- a/xrcf/tests/convert/experimental_to_mlir.rs
+++ b/xrcf/tests/convert/experimental_to_mlir.rs
@@ -3,6 +3,7 @@ extern crate xrcf;
 use indoc::indoc;
 use std::panic::Location;
 use xrcf::ir::ModuleOp;
+use xrcf::shared::SharedExt;
 use xrcf::tester::Tester;
 
 fn flags() -> Vec<&'static str> {
@@ -37,7 +38,7 @@ fn test_constant() {
     let caller = Location::caller();
     let (module, actual) = Tester::transform(flags(), src);
     Tester::verify(module.clone());
-    let module = module.try_read().unwrap();
+    let module = module.re();
     assert!(module.as_any().is::<ModuleOp>());
     Tester::check_lines_contain(&actual, expected, caller);
 }

--- a/xrcf/tests/convert/mlir_to_llvmir.rs
+++ b/xrcf/tests/convert/mlir_to_llvmir.rs
@@ -36,7 +36,7 @@ fn test_constant() {
     "#};
     let (module, actual) = Tester::transform(flags(), src);
     Tester::verify(module.clone());
-    let module = module.re();
+    let module = module.rd();
     assert!(module.as_any().is::<targ3t::llvmir::ModuleOp>());
     Tester::check_lines_contain(&actual, expected, Location::caller());
 }

--- a/xrcf/tests/convert/mlir_to_llvmir.rs
+++ b/xrcf/tests/convert/mlir_to_llvmir.rs
@@ -2,6 +2,7 @@ extern crate xrcf;
 
 use indoc::indoc;
 use std::panic::Location;
+use xrcf::shared::SharedExt;
 use xrcf::targ3t;
 use xrcf::tester::Tester;
 
@@ -35,7 +36,7 @@ fn test_constant() {
     "#};
     let (module, actual) = Tester::transform(flags(), src);
     Tester::verify(module.clone());
-    let module = module.try_read().unwrap();
+    let module = module.re();
     assert!(module.as_any().is::<targ3t::llvmir::ModuleOp>());
     Tester::check_lines_contain(&actual, expected, Location::caller());
 }


### PR DESCRIPTION
Introduces `Shared` and `SharedExt` as a convenience typ and trait that turn
```rust
use std::sync::{Arc, RwLock};

let lock = Arc::new(RwLock::new(42));
assert_eq!(*lock.try_read().unwrap(), 42);
```
into
```rust
use std::sync::{Arc, RwLock};
use xrcf::shared::{Shared, SharedExt};

let lock = Shared::new(42.into());
assert_eq!(*lock.re(), 42);
```

This is a tradeoff between making it easier to use the `Arc<RwLock<T>>` while also not wrapping it in a completely different object which would add another layer of indirection.

The most important thing is now that thanks to `SharedExt`, writing `lock.rd().` lists the available methods. This is much easier to quickly check the available methods than via `lock.try_read().unwrap().`. Another benefit is that `re` is much shorter so it's more likely to fit into one line. One-liners work particularly well in Rust do to when variables are freed, see https://xrcf.org/blog/iterators/ for more information.