### PR TITLE
Specify `Sync` and `Send`

### DIFF
--- a/xrcf/Cargo.toml
+++ b/xrcf/Cargo.toml
@@ -17,6 +17,7 @@ clap = { version = "4.5", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 parking_lot = { version = "0.12", features = ["deadlock_detection"] }
+rayon = "1.10"
 
 [dev-dependencies]
 indoc = "2"

--- a/xrcf/src/convert/mod.rs
+++ b/xrcf/src/convert/mod.rs
@@ -10,6 +10,7 @@ use crate::ir::Op;
 use crate::shared::Shared;
 use crate::shared::SharedExt;
 use anyhow::Result;
+use rayon::prelude::*;
 use std::sync::Arc;
 use tracing::debug;
 
@@ -92,12 +93,12 @@ fn apply_rewrites_core(
         let changed = root
             .rd()
             .ops()
-            .iter()
+            .par_iter()
             .map(|op| {
                 let indent = indent + 1;
                 apply_rewrites_core(op.clone(), rewrites, indent).expect("TODO BUBBLE UP")
             })
-            .find(|result| result.is_changed().is_some());
+            .find_first(|result| result.is_changed().is_some());
         if let Some(_op) = changed {
             let root_passthrough = ChangedOp::new(root.clone());
             let root_passthrough = RewriteResult::Changed(root_passthrough);

--- a/xrcf/src/convert/mod.rs
+++ b/xrcf/src/convert/mod.rs
@@ -98,9 +98,7 @@ fn apply_rewrites_core(
                 let indent = indent + 1;
                 apply_rewrites_core(op.clone(), rewrites, indent).expect("TODO BUBBLE UP")
             })
-            .skip_while(|result| result.is_changed().is_none())
-            .take(1)
-            .next();
+            .find(|result| result.is_changed().is_some());
         if let Some(_op) = changed {
             let root_passthrough = ChangedOp::new(root.clone());
             let root_passthrough = RewriteResult::Changed(root_passthrough);

--- a/xrcf/src/convert/mod.rs
+++ b/xrcf/src/convert/mod.rs
@@ -10,7 +10,6 @@ use crate::ir::Op;
 use crate::shared::Shared;
 use crate::shared::SharedExt;
 use anyhow::Result;
-use rayon::prelude::*;
 use std::sync::Arc;
 use tracing::debug;
 

--- a/xrcf/src/ir/attribute.rs
+++ b/xrcf/src/ir/attribute.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 /// Attributes are known-constant values of operations (a variable is not allowed).
 /// Attributes belong to operations and can be used to, for example, specify
 /// a SSA value.
-pub trait Attribute {
+pub trait Attribute: Send + Sync {
     fn from_str(value: &str) -> Self
     where
         Self: Sized;

--- a/xrcf/src/ir/op.rs
+++ b/xrcf/src/ir/op.rs
@@ -19,7 +19,12 @@ use std::sync::Arc;
 ///
 /// See [Operation] for more information about the relationship between
 /// [Operation] and [Op].
-pub trait Op {
+///
+/// ```
+/// fn is_sharable<T: Send + Sync>() {}
+///
+/// ```
+pub trait Op: Send + Sync {
     fn operation_name() -> OperationName
     where
         Self: Sized;

--- a/xrcf/src/ir/typ.rs
+++ b/xrcf/src/ir/typ.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::str::FromStr;
-pub trait Type {
+pub trait Type: Send + Sync {
     /// Display the type.
     ///
     /// This has to be implemented by each type so that calls to `Display::fmt`

--- a/xrcf/src/lib.rs
+++ b/xrcf/src/lib.rs
@@ -38,7 +38,6 @@
 //! So, the long-term goal of this project is to provide an easy-to-use set of tools that can be used to build your own compiler.
 //! In other words, it should be easy to build a compiler that can transform your favorite language to this project's core IR, and then it should be easy to transform this to various platforms such as GPUs, CPUs, and TPUs.
 #![allow(clippy::new_without_default)]
-#![allow(clippy::arc_with_non_send_sync)]
 
 mod canonicalize;
 pub mod convert;


### PR DESCRIPTION
Implement some basic multithreading (fix #37). After reading Rust for Rustaceans, chapter 10 on concurrency (and parallelism), it seems that `rayon` could be a suitable way to implement it (EDIT: Yes looks like it. `rayon` is also used within the Rust compiler together with the query-based approach). The book says that Shared Memory is usually the best approach if threads need to "jointly update some shared state in a way that does not commute". But on the other hand, having a Worker Pool via `rayon` does look appealing too. The API is very simple. I think it would be possible to figure out beforehand which rewrites have side-effects and which don't, then based on that `rayon` can probably be called differently. For example, say if 2 out of 6 op rewrites have side-effects (`| | x | | x`) , then maybe the `iter` can be split up in multiple parts (`| |`, `x`, `| |`, `x`). This would lose some concurrency of course since it essentially introduces 4 barriers (synchronization points), but depending on how many rewrites have side-effects this could still save a lot of time.

EDIT: So it crashes with out of bounds errors like trying to access a block that has been removed. This makes sense. But how to stop rewrites in a certain area if one rewrite already knows that it need to rewrite a few layers up? Or maybe the locks are currently not correct? Certain rewrites should just lock a whole area? The book talks about that only commutatitivy is a problem for `rayon` which uses a Worker Pool. Or maybe the rewrites should take multiple locks? A more hands-off approach could be to determine independent regions beforehand and then just process those parallel (like Mojo did with LLVM: https://youtu.be/yuSBEXkjfEA). 

EDIT2: Interesting text from https://stackoverflow.com/questions/4430001/: "In practice, fine-grained parallelism in compiler passes probably isn't worth the overhead of synchronization (and the inevitable bugs when a pass touches more than it claims to) given that individual source files in large programs can be compiled in parallel. The different pass classes are primarily useful for documentation. They can also help in scheduling passes in a cache-friendly way; for example, when running a bunch of FunctionPasses on all the translation unit's functions, it's faster to run each pass on one function (keeping it in cache) before moving to the next function."

EDIT 3: Probably need to think about this in terms of separate parts like parser, optimizer, etc. From the Rust compiler docs: "As of November 2024, most of the rust compiler is now parallelized.

The codegen part is executed concurrently by default. You can use the -C codegen-units=n option to control the number of concurrent tasks.
The parts after HIR lowering to codegen such as type checking, borrowing checking, and mir optimization are parallelized in the nightly version. Currently, they are executed in serial by default, and parallelization is manually enabled by the user using the -Z threads = n option.
Other parts, such as lexical parsing, HIR lowering, and macro expansion, are still executed in serial mode"

Here codegen as far as I understand means llvm. This part is already parallelized since 2015: "In a normal build we generate an LLVM module for each crate. LLVM then processes that module into an object file, which is eventually linked with other object files (from other crates or libs) to make the final program. Under parallel codegen, rustc creates multiple LLVM modules per crate (one per ‘codegen unit’), these modules are processed in parallel to produce multiple object files. Then these object files are linked together to produce a single object file for the whole crate. That object file can then be further linked as normal."

The linker seems to be single threaded more generally. In a large cmake based project cpu utilization went visually down to one during linking.

EDIT 4: The query system is mostly meant to make incremental compilation faster, but it has benefits for parallelization too since query results are immutable and query providers can only access data via the query context which allows the query context to take care of synchronizing access (https://rustc-dev-guide.rust-lang.org/parallel-rustc.html#query-system). Also from [Ole Fredriksson's blog](https://ollef.github.io/blog/posts/query-based-compilers.html): "Query-based compilers are also surprisingly easy to parallelise. Since we're allowed to make any query at any time, and they're memoised the first time they're run, we can fire off queries in parallel without having to think much. In Sixty, the default behaviour is for all input modules to be type checked in parallel."

EDIT 5: According to matklad, a query-based compiler might be overkill for many languages (https://www.reddit.com/r/ProgrammingLanguages/comments/hfs53y/comment/fyeri3v/). Usually it's fine for parallelism to do it on a higher level (like the file-level).