### PR TITLE
Allow rewriting in parallel

### DIFF
--- a/wea/src/lib.rs
+++ b/wea/src/lib.rs
@@ -6,7 +6,6 @@
 //! To import some `X` from inside this library, it may sometimes be necessary
 //! to add a `pub use::X` to `main.rs`.
 #![allow(clippy::new_without_default)]
-#![allow(clippy::arc_with_non_send_sync)]
 
 mod op;
 mod wea_to_mlir;

--- a/wea/src/wea_to_mlir.rs
+++ b/wea/src/wea_to_mlir.rs
@@ -70,8 +70,7 @@ impl Rewrite for PlusLowering {
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
         let op = op.as_any().downcast_ref::<op::PlusOp>().unwrap();
-        let operation = op.operation().clone();
-        let new_op = arith::AddiOp::from_operation_arc(operation);
+        let new_op = arith::AddiOp::from_operation_arc(op.operation().clone());
         let new_op = Shared::new(new_op.into());
         op.replace(new_op.clone());
         Ok(RewriteResult::Changed(ChangedOp::new(new_op)))

--- a/xrcf/Cargo.toml
+++ b/xrcf/Cargo.toml
@@ -11,6 +11,10 @@ repository.workspace = true
 homepage.workspace = true
 readme = "../README.md"
 
+[[bench]]
+name = "func_to_llvm"
+harness = false
+
 [dependencies]
 anyhow = "1.0.86"
 clap = { version = "4.5", features = ["derive"] }
@@ -20,6 +24,7 @@ parking_lot = { version = "0.12", features = ["deadlock_detection"] }
 wasmtime = { version = "28.0.0", features = ["cranelift"] }
 
 [dev-dependencies]
+criterion = { version = "0.5" }
 indoc = "2"
 xrcf = { path = ".", features = ["test-utils"] }
 

--- a/xrcf/Cargo.toml
+++ b/xrcf/Cargo.toml
@@ -18,9 +18,10 @@ harness = false
 [dependencies]
 anyhow = "1.0.86"
 clap = { version = "4.5", features = ["derive"] }
+parking_lot = { version = "0.12", features = ["deadlock_detection"] }
+rayon = "1.10"
 tracing = "0.1"
 tracing-subscriber = "0.3"
-parking_lot = { version = "0.12", features = ["deadlock_detection"] }
 wasmtime = { version = "28.0.0", features = ["cranelift"] }
 
 [dev-dependencies]

--- a/xrcf/benches/func_to_llvm.rs
+++ b/xrcf/benches/func_to_llvm.rs
@@ -1,10 +1,10 @@
 extern crate xrcf;
 
-use indoc::indoc;
-use std::panic::Location;
 use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::Criterion;
+use indoc::indoc;
+use std::panic::Location;
 use xrcf::tester::DefaultTester;
 
 fn flags() -> Vec<&'static str> {

--- a/xrcf/benches/func_to_llvm.rs
+++ b/xrcf/benches/func_to_llvm.rs
@@ -1,0 +1,44 @@
+extern crate xrcf;
+
+use indoc::indoc;
+use std::panic::Location;
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::Criterion;
+use xrcf::tester::DefaultTester;
+
+fn flags() -> Vec<&'static str> {
+    vec!["--tester-no-print", "--convert-func-to-llvm"]
+}
+
+fn benchmark_rewrite() {
+    DefaultTester::init_tracing();
+    let src = indoc! {"
+    func.func @add_one(%arg0 : i32) -> i32 {
+        %0 = arith.constant 1 : i32
+        %1 = arith.addi %0, %arg0 : i32
+        return %1 : i32
+    }
+    "};
+    let src = &src.repeat(100);
+    let expected = indoc! {"
+    llvm.func @add_one(%arg0 : i32) -> i32 {
+        %0 = llvm.mlir.constant(1 : i32) : i32
+        %1 = llvm.add %0, %arg0 : i32
+        llvm.return %1 : i32
+    }
+    "};
+    let (module, actual) = DefaultTester::transform(flags(), src);
+    DefaultTester::verify(module);
+    DefaultTester::check_lines_contain(&actual, expected, Location::caller());
+}
+
+fn bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rewrite");
+    group.sample_size(10);
+    group.bench_function("benchmark_rewrite", |b| b.iter(benchmark_rewrite));
+    group.finish();
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);

--- a/xrcf/src/convert/func_to_llvm.rs
+++ b/xrcf/src/convert/func_to_llvm.rs
@@ -19,7 +19,7 @@ impl Rewrite for AddLowering {
     fn name(&self) -> &'static str {
         "func_to_llvm::AddOpLowering"
     }
-    fn parallizable(&self) -> bool {
+    fn parallelizable(&self) -> bool {
         true
     }
     fn is_match(&self, op: &dyn Op) -> Result<bool> {
@@ -41,7 +41,7 @@ impl Rewrite for CallLowering {
     fn name(&self) -> &'static str {
         "func_to_llvm::CallLowering"
     }
-    fn parallizable(&self) -> bool {
+    fn parallelizable(&self) -> bool {
         true
     }
     fn is_match(&self, op: &dyn Op) -> Result<bool> {
@@ -65,7 +65,7 @@ impl Rewrite for ConstantOpLowering {
     fn name(&self) -> &'static str {
         "func_to_llvm::ConstantOpLowering"
     }
-    fn parallizable(&self) -> bool {
+    fn parallelizable(&self) -> bool {
         true
     }
     fn is_match(&self, op: &dyn Op) -> Result<bool> {
@@ -87,7 +87,7 @@ impl Rewrite for FuncLowering {
     fn name(&self) -> &'static str {
         "func_to_llvm::FuncLowering"
     }
-    fn parallizable(&self) -> bool {
+    fn parallelizable(&self) -> bool {
         true
     }
     fn is_match(&self, op: &dyn Op) -> Result<bool> {
@@ -125,7 +125,7 @@ impl Rewrite for ReturnLowering {
     fn name(&self) -> &'static str {
         "func_to_llvm::ReturnLowering"
     }
-    fn parallizable(&self) -> bool {
+    fn parallelizable(&self) -> bool {
         true
     }
     fn is_match(&self, op: &dyn Op) -> Result<bool> {

--- a/xrcf/src/convert/func_to_llvm.rs
+++ b/xrcf/src/convert/func_to_llvm.rs
@@ -19,6 +19,9 @@ impl Rewrite for AddLowering {
     fn name(&self) -> &'static str {
         "func_to_llvm::AddOpLowering"
     }
+    fn parallizable(&self) -> bool {
+        true
+    }
     fn is_match(&self, op: &dyn Op) -> Result<bool> {
         Ok(op.as_any().is::<arith::AddiOp>())
     }
@@ -37,6 +40,9 @@ struct CallLowering;
 impl Rewrite for CallLowering {
     fn name(&self) -> &'static str {
         "func_to_llvm::CallLowering"
+    }
+    fn parallizable(&self) -> bool {
+        true
     }
     fn is_match(&self, op: &dyn Op) -> Result<bool> {
         Ok(op.as_any().is::<func::CallOp>())
@@ -59,6 +65,9 @@ impl Rewrite for ConstantOpLowering {
     fn name(&self) -> &'static str {
         "func_to_llvm::ConstantOpLowering"
     }
+    fn parallizable(&self) -> bool {
+        true
+    }
     fn is_match(&self, op: &dyn Op) -> Result<bool> {
         Ok(op.as_any().is::<arith::ConstantOp>())
     }
@@ -77,6 +86,9 @@ struct FuncLowering;
 impl Rewrite for FuncLowering {
     fn name(&self) -> &'static str {
         "func_to_llvm::FuncLowering"
+    }
+    fn parallizable(&self) -> bool {
+        true
     }
     fn is_match(&self, op: &dyn Op) -> Result<bool> {
         Ok(op.as_any().is::<func::FuncOp>())
@@ -112,6 +124,9 @@ struct ReturnLowering;
 impl Rewrite for ReturnLowering {
     fn name(&self) -> &'static str {
         "func_to_llvm::ReturnLowering"
+    }
+    fn parallizable(&self) -> bool {
+        true
     }
     fn is_match(&self, op: &dyn Op) -> Result<bool> {
         Ok(op.as_any().is::<func::ReturnOp>())

--- a/xrcf/src/convert/mod.rs
+++ b/xrcf/src/convert/mod.rs
@@ -122,7 +122,7 @@ fn apply_rewrites_helper(
 }
 
 pub fn apply_rewrites(root: Shared<dyn Op>, rewrites: &[&dyn Rewrite]) -> Result<RewriteResult> {
-    let max_iterations = 1024;
+    let max_iterations = 10240;
     let mut root = root;
     let mut has_changed = false;
     for _ in 0..max_iterations {

--- a/xrcf/src/ir/attribute.rs
+++ b/xrcf/src/ir/attribute.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 /// Attributes are known-constant values of operations (a variable is not allowed).
 /// Attributes belong to operations and can be used to, for example, specify
 /// a SSA value.
-pub trait Attribute {
+pub trait Attribute: Send + Sync {
     fn from_str(value: &str) -> Self
     where
         Self: Sized;

--- a/xrcf/src/ir/op.rs
+++ b/xrcf/src/ir/op.rs
@@ -34,7 +34,7 @@ pub struct Prefixes {
 ///
 /// See [Operation] for more information about the relationship between
 /// [Operation] and [Op].
-pub trait Op {
+pub trait Op: Send + Sync {
     fn operation_name() -> OperationName
     where
         Self: Sized;

--- a/xrcf/src/ir/typ.rs
+++ b/xrcf/src/ir/typ.rs
@@ -9,7 +9,8 @@ use anyhow::Result;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::str::FromStr;
-pub trait Type {
+
+pub trait Type: Send + Sync {
     /// Display the type.
     ///
     /// This has to be implemented by each type so that calls to `Display::fmt`

--- a/xrcf/src/tester.rs
+++ b/xrcf/src/tester.rs
@@ -125,8 +125,11 @@ impl<P: ParserDispatch, T: TransformDispatch> Tester<P, T> {
     pub fn transform(arguments: Vec<&str>, src: &str) -> (Shared<dyn Op>, String) {
         let src = src.trim();
         let module = Parser::<P>::parse(src).unwrap();
-        let msg = format!("Before (transform {arguments:?})");
-        Self::print_heading(&msg, &src);
+        let should_print = !arguments.contains(&"--tester-no-print");
+        if should_print {
+            let msg = format!("Before (transform {arguments:?})");
+            Self::print_heading(&msg, &src);
+        }
 
         for arg in arguments.clone() {
             if arg.starts_with("convert-") {
@@ -143,8 +146,10 @@ impl<P: ParserDispatch, T: TransformDispatch> Tester<P, T> {
             }
         };
         let actual = format!("{}", new_root_op.rd());
-        let msg = format!("After (transform {arguments:?})");
-        Self::print_heading(&msg, &actual);
+        if should_print {
+            let msg = format!("After (transform {arguments:?})");
+            Self::print_heading(&msg, &actual);
+        }
         (new_root_op, actual)
     }
     fn verify_core(op: Shared<dyn Op>) {


### PR DESCRIPTION
## Benchmark

The benchmark can be executed via `cargo bench`. During the benchmark, xrcf rewrites the following function that is repeated 100 times in a file
```mlir
func.func @add_one(%arg0 : i32) -> i32 {
    %0 = arith.constant 1 : i32
    %1 = arith.addi %0, %arg0 : i32
    return %1 : i32
}
```
to
```mlir
llvm.func @add_one(%arg0 : i32) -> i32 {
    %0 = llvm.mlir.constant(1 : i32) : i32
    %1 = llvm.add %0, %arg0 : i32
    llvm.return %1 : i32
}
```

## Result

Before:
```raw
time:   [47.268 ms 47.330 ms 47.377 ms]
```

After:
```raw
time:   [24.160 ms 24.355 ms 24.558 ms]
```

The overhead of `DefaultTester::verify` is negligible here because the rewrite with one repeat takes 0.4 ms.

## Discussion

Closes https://github.com/rikhuijzer/xrcf/issues/37. 

This now closes the discussion in https://github.com/rikhuijzer/xrcf/pull/41. In summary, query-based compilers are nice, but not the best fit for this project. Many compilers such as C, Zig ([source](https://youtu.be/IroPQ150F6c?t=1936)), Mojo ([source](https://youtu.be/yuSBEXkjfEA)), and Cranelift are not query-based but instead compile files in parallel and then link the files sequentially. (Note that linking means matching up, for example, function definitions with function calls.)