### PR TITLE
Remove `Rewrite.is_match`

### DIFF
--- a/arnoldc/src/arnold_to_mlir.rs
+++ b/arnoldc/src/arnold_to_mlir.rs
@@ -34,12 +34,12 @@ impl Rewrite for CallLowering {
     fn name(&self) -> &'static str {
         "example_to_mlir::CallLowering"
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<arnold::CallOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
-        let op = op.as_any().downcast_ref::<arnold::CallOp>().unwrap();
+        let op = match op.as_any().downcast_ref::<arnold::CallOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
         let identifier = op.identifier().unwrap();
         let operation = op.operation();
         let mut new_op = func::CallOp::from_operation_arc(operation.clone());
@@ -68,12 +68,12 @@ impl Rewrite for DeclareIntLowering {
     fn name(&self) -> &'static str {
         "example_to_mlir::DeclareIntLowering"
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<arnold::DeclareIntOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
-        let op = op.as_any().downcast_ref::<arnold::DeclareIntOp>().unwrap();
+        let op = match op.as_any().downcast_ref::<arnold::DeclareIntOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
         op.operation().rd().rename_variables(&RENAMER)?;
 
         let successors = op.operation().rd().successors();
@@ -101,12 +101,12 @@ impl Rewrite for FuncLowering {
     fn name(&self) -> &'static str {
         "example_to_mlir::FuncLowering"
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<arnold::BeginMainOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
-        let op = op.as_any().downcast_ref::<arnold::BeginMainOp>().unwrap();
+        let op = match op.as_any().downcast_ref::<arnold::BeginMainOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
         let identifier = "@main";
         let operation = op.operation();
         let mut new_op = func::FuncOp::from_operation_arc(operation.clone());
@@ -141,12 +141,12 @@ impl Rewrite for IfLowering {
     fn name(&self) -> &'static str {
         "example_to_mlir::IfLowering"
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<arnold::IfOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
-        let op = op.as_any().downcast_ref::<arnold::IfOp>().unwrap();
+        let op = match op.as_any().downcast_ref::<arnold::IfOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
         let operation = op.operation();
         let mut new_op = scf::IfOp::from_operation_arc(operation.clone());
         new_op.set_then(op.then().clone());
@@ -233,10 +233,10 @@ impl Rewrite for ModuleLowering {
     fn name(&self) -> &'static str {
         "example_to_mlir::ModuleLowering"
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<xrcf::ir::ModuleOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
+        if !op.rd().as_any().is::<xrcf::ir::ModuleOp>() {
+            return Ok(RewriteResult::Unchanged);
+        }
         Self::ensure_main_returns_zero(op.clone())
     }
 }
@@ -247,12 +247,12 @@ impl Rewrite for PrintLowering {
     fn name(&self) -> &'static str {
         "example_to_mlir::PrintLowering"
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<arnold::PrintOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
-        let op = op.as_any().downcast_ref::<arnold::PrintOp>().unwrap();
+        let op = match op.as_any().downcast_ref::<arnold::PrintOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
         let mut operation = Operation::default();
         operation.set_name(experimental::PrintfOp::operation_name());
         let operation = Shared::new(operation.into());

--- a/wea/src/wea_to_mlir.rs
+++ b/wea/src/wea_to_mlir.rs
@@ -41,12 +41,12 @@ impl Rewrite for FuncLowering {
     fn name(&self) -> &'static str {
         "convert_wea_to_mlir::FuncLowering"
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<op::FuncOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
-        let op = op.as_any().downcast_ref::<op::FuncOp>().unwrap();
+        let op = match op.as_any().downcast_ref::<op::FuncOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
         let operation = op.operation().clone();
         let mut new_op = func::FuncOp::from_operation_arc(operation);
         let identifier = format!("@{}", op.identifier.as_ref().expect("identifier not set"));
@@ -64,12 +64,12 @@ impl Rewrite for PlusLowering {
     fn name(&self) -> &'static str {
         "convert_wea_to_mlir::PlusLowering"
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<op::PlusOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
-        let op = op.as_any().downcast_ref::<op::PlusOp>().unwrap();
+        let op = match op.as_any().downcast_ref::<op::PlusOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
         let new_op = arith::AddiOp::from_operation_arc(op.operation().clone());
         let new_op = Shared::new(new_op.into());
         op.replace(new_op.clone());

--- a/xrcf/src/canonicalize.rs
+++ b/xrcf/src/canonicalize.rs
@@ -15,9 +15,6 @@ impl Rewrite for CanonicalizeOp {
     fn name(&self) -> &'static str {
         "canonicalize::CanonicalizeOp"
     }
-    fn is_match(&self, _op: &dyn Op) -> Result<bool> {
-        Ok(true)
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let result = op.rd().canonicalize();
         Ok(result)
@@ -29,9 +26,6 @@ pub struct DeadCodeElimination;
 impl Rewrite for DeadCodeElimination {
     fn name(&self) -> &'static str {
         "canonicalize::DeadCodeElimination"
-    }
-    fn is_match(&self, _op: &dyn Op) -> Result<bool> {
-        Ok(true)
     }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let readonly = op.clone();

--- a/xrcf/src/convert/cf_to_llvm.rs
+++ b/xrcf/src/convert/cf_to_llvm.rs
@@ -16,12 +16,12 @@ impl Rewrite for BranchLowering {
     fn name(&self) -> &'static str {
         "func_to_llvm::BranchLowering"
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<cf::BranchOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
-        let op = op.as_any().downcast_ref::<cf::BranchOp>().unwrap();
+        let op = match op.as_any().downcast_ref::<cf::BranchOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
         let new_op = llvm::BranchOp::from_operation_arc(op.operation().clone());
         let new_op = Shared::new(new_op.into());
         op.replace(new_op.clone());
@@ -35,12 +35,12 @@ impl Rewrite for CondBranchLowering {
     fn name(&self) -> &'static str {
         "func_to_llvm::CondBranchLowering"
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<cf::CondBranchOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
-        let op = op.as_any().downcast_ref::<cf::CondBranchOp>().unwrap();
+        let op = match op.as_any().downcast_ref::<cf::CondBranchOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
         let new_op = llvm::CondBranchOp::from_operation_arc(op.operation().clone());
         let new_op = Shared::new(new_op.into());
         op.replace(new_op.clone());

--- a/xrcf/src/convert/experimental_to_mlir.rs
+++ b/xrcf/src/convert/experimental_to_mlir.rs
@@ -214,17 +214,17 @@ impl Rewrite for PrintLowering {
     fn name(&self) -> &'static str {
         "experimental_to_mlir::PrintLowering"
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<dialect::experimental::PrintfOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
-        let op_clone = op.clone();
-        let set_varargs = 1 < op.rd().operation().rd().operands().vec().rd().len();
-        let op_rd = op_clone.rd();
-        let op_rd = op_rd
+        let op_rd = op.clone();
+        let op_rd = op_rd.rd();
+        let op_rd = match op_rd
             .as_any()
             .downcast_ref::<dialect::experimental::PrintfOp>()
-            .unwrap();
+        {
+            Some(op_rd) => op_rd,
+            None => return Ok(RewriteResult::Unchanged),
+        };
+        let set_varargs = 1 < op.rd().operation().rd().operands().vec().rd().len();
         let parent = op_rd.operation().rd().parent();
         let parent = parent.expect("no parent");
         let (text, len) = PrintLowering::text_constant(&parent, op_rd);

--- a/xrcf/src/convert/func_to_llvm.rs
+++ b/xrcf/src/convert/func_to_llvm.rs
@@ -22,11 +22,12 @@ impl Rewrite for AddLowering {
     fn parallelizable(&self) -> bool {
         true
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<arith::AddiOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
+        let op = match op.as_any().downcast_ref::<arith::AddiOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
         let lowered = llvm::AddOp::from_operation_arc(op.operation().clone());
         let new_op = Shared::new(lowered.into());
         op.replace(new_op.clone());
@@ -44,12 +45,12 @@ impl Rewrite for CallLowering {
     fn parallelizable(&self) -> bool {
         true
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<func::CallOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
-        let op = op.as_any().downcast_ref::<func::CallOp>().unwrap();
+        let op = match op.as_any().downcast_ref::<func::CallOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
         let mut new_op = llvm::CallOp::from_operation_arc(op.operation().clone());
         new_op.set_identifier(op.identifier().unwrap());
         let new_op = Shared::new(new_op.into());
@@ -68,11 +69,12 @@ impl Rewrite for ConstantOpLowering {
     fn parallelizable(&self) -> bool {
         true
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<arith::ConstantOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
+        let op = match op.as_any().downcast_ref::<arith::ConstantOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
         let lowered = llvm::ConstantOp::from_operation_arc(op.operation().clone());
         let new_op = Shared::new(lowered.into());
         op.replace(new_op.clone());
@@ -90,12 +92,12 @@ impl Rewrite for FuncLowering {
     fn parallelizable(&self) -> bool {
         true
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<func::FuncOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
-        let op = op.as_any().downcast_ref::<func::FuncOp>().unwrap();
+        let op = match op.as_any().downcast_ref::<func::FuncOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
         let operation = op.operation();
         {
             let name = operation.rd().name();
@@ -128,12 +130,12 @@ impl Rewrite for ReturnLowering {
     fn parallelizable(&self) -> bool {
         true
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<func::ReturnOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
-        let op = op.as_any().downcast_ref::<func::ReturnOp>().unwrap();
+        let op = match op.as_any().downcast_ref::<func::ReturnOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
         let lowered = llvm::ReturnOp::from_operation_arc(op.operation().clone());
         let new_op = Shared::new(lowered.into());
         op.replace(new_op.clone());

--- a/xrcf/src/convert/mlir_to_llvmir.rs
+++ b/xrcf/src/convert/mlir_to_llvmir.rs
@@ -70,9 +70,6 @@ impl Rewrite for AddLowering {
     fn name(&self) -> &'static str {
         "mlir_to_llvmir::AddLowering"
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<dialect::llvm::AddOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
         let op = op.as_any().downcast_ref::<dialect::llvm::AddOp>().unwrap();
@@ -91,15 +88,12 @@ impl Rewrite for AllocaLowering {
     fn name(&self) -> &'static str {
         "mlir_to_llvmir::AllocaLowering"
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<dialect::llvm::AllocaOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
-        let op = op
-            .as_any()
-            .downcast_ref::<dialect::llvm::AllocaOp>()
-            .unwrap();
+        let op = match op.as_any().downcast_ref::<dialect::llvm::AllocaOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
         let operation = op.operation();
         let mut new_op = targ3t::llvmir::AllocaOp::from_operation_arc(operation.clone());
         operation
@@ -124,25 +118,23 @@ impl Rewrite for BranchLowering {
     fn name(&self) -> &'static str {
         "mlir_to_llvmir::BranchLowering"
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        if op.as_any().is::<dialect::llvm::BranchOp>() {
-            // Check whether [MergeLowering] has already removed the operands.
-            Ok(op.operation().rd().operands().into_iter().all(|operand| {
-                let operand = operand.rd();
-                let value = operand.value();
-                let value = value.rd();
-                matches!(&*value, Value::BlockLabel(_) | Value::BlockPtr(_))
-            }))
-        } else {
-            Ok(false)
-        }
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
-        let op = op
-            .as_any()
-            .downcast_ref::<dialect::llvm::BranchOp>()
-            .unwrap();
+        let op = match op.as_any().downcast_ref::<dialect::llvm::BranchOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
+        let valid_values = op.operation().rd().operands().into_iter().all(|operand| {
+            let operand = operand.rd();
+            let value = operand.value();
+            let value = value.rd();
+            matches!(&*value, Value::BlockLabel(_) | Value::BlockPtr(_))
+        });
+        if !valid_values {
+            // [MergeLowering] has not yet removed the operands.
+            return Ok(RewriteResult::Unchanged);
+        }
+
         let operation = op.operation();
         let new_op = targ3t::llvmir::BranchOp::from_operation_arc(operation.clone());
         let new_op = Shared::new(new_op.into());
@@ -157,12 +149,12 @@ impl Rewrite for CallLowering {
     fn name(&self) -> &'static str {
         "mlir_to_llvmir::CallLowering"
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<dialect::llvm::CallOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
-        let op = op.as_any().downcast_ref::<dialect::llvm::CallOp>().unwrap();
+        let op = match op.as_any().downcast_ref::<dialect::llvm::CallOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
         let operation = op.operation();
 
         let mut new_op = targ3t::llvmir::CallOp::from_operation_arc(operation.clone());
@@ -188,15 +180,12 @@ impl Rewrite for CondBranchLowering {
     fn name(&self) -> &'static str {
         "mlir_to_llvmir::CondBranchLowering"
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<dialect::llvm::CondBranchOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
-        let op = op
-            .as_any()
-            .downcast_ref::<dialect::llvm::CondBranchOp>()
-            .unwrap();
+        let op = match op.as_any().downcast_ref::<dialect::llvm::CondBranchOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
         let operation = op.operation();
         let new_op = targ3t::llvmir::BranchOp::from_operation_arc(operation.clone());
         replace_constant_operands(&new_op);
@@ -243,12 +232,12 @@ impl Rewrite for FuncLowering {
     fn name(&self) -> &'static str {
         "mlir_to_llvmir::FuncLowering"
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<dialect::llvm::FuncOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
-        let op = op.as_any().downcast_ref::<dialect::llvm::FuncOp>().unwrap();
+        let op = match op.as_any().downcast_ref::<dialect::llvm::FuncOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
         let operation = op.operation();
         let mut new_op = targ3t::llvmir::FuncOp::from_operation_arc(operation.clone());
 
@@ -444,30 +433,32 @@ fn remove_caller_operands(block: Shared<Block>) {
     }
 }
 
+fn one_child_block_has_argument(op: &dyn Op) -> Result<bool> {
+    if !op.is_func() {
+        return Ok(false);
+    }
+    let operation = op.operation();
+    if operation.rd().region().is_none() {
+        return Ok(false);
+    }
+    for block in operation.rd().blocks().into_iter() {
+        let block = block.rd();
+        let has_argument = !block.arguments().vec().rd().is_empty();
+        if has_argument {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 impl Rewrite for MergeLowering {
     fn name(&self) -> &'static str {
         "mlir_to_llvmir::MergeLowering"
     }
-    /// Return true if the operation is a function where one of the children
-    /// blocks has an argument.
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        if !op.is_func() {
-            return Ok(false);
-        }
-        let operation = op.operation();
-        if operation.rd().region().is_none() {
-            return Ok(false);
-        }
-        for block in operation.rd().blocks().into_iter() {
-            let block = block.rd();
-            let has_argument = !block.arguments().vec().rd().is_empty();
-            if has_argument {
-                return Ok(true);
-            }
-        }
-        Ok(false)
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
+        if !one_child_block_has_argument(&*op.rd())? {
+            return Ok(RewriteResult::Unchanged);
+        }
         let blocks = op.rd().operation().rd().region().unwrap().rd().blocks();
         for block in blocks.into_iter() {
             let block_read = block.rd();
@@ -487,10 +478,10 @@ impl Rewrite for ModuleLowering {
     fn name(&self) -> &'static str {
         "mlir_to_llvmir::ModuleLowering"
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<ir::ModuleOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
+        if !op.rd().as_any().is::<ir::ModuleOp>() {
+            return Ok(RewriteResult::Unchanged);
+        }
         let operation = op.rd().operation().clone();
         let new_op = targ3t::llvmir::ModuleOp::from_operation_arc(operation);
         let new_op = Shared::new(new_op.into());
@@ -505,15 +496,12 @@ impl Rewrite for ReturnLowering {
     fn name(&self) -> &'static str {
         "mlir_to_llvmir::ReturnLowering"
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<dialect::llvm::ReturnOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
-        let op = op
-            .as_any()
-            .downcast_ref::<dialect::llvm::ReturnOp>()
-            .unwrap();
+        let op = match op.as_any().downcast_ref::<dialect::llvm::ReturnOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
         let operation = op.operation();
         let new_op = targ3t::llvmir::ReturnOp::from_operation_arc(operation.clone());
         replace_constant_operands(&new_op);
@@ -529,15 +517,12 @@ impl Rewrite for StoreLowering {
     fn name(&self) -> &'static str {
         "mlir_to_llvmir::ReturnLowering"
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<dialect::llvm::StoreOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
-        let op = op
-            .as_any()
-            .downcast_ref::<dialect::llvm::StoreOp>()
-            .unwrap();
+        let op = match op.as_any().downcast_ref::<dialect::llvm::StoreOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
         let operation = op.operation();
         let mut new_op = targ3t::llvmir::StoreOp::from_operation_arc(operation.clone());
         {

--- a/xrcf/src/convert/mlir_to_wat.rs
+++ b/xrcf/src/convert/mlir_to_wat.rs
@@ -20,12 +20,12 @@ impl Rewrite for AddiLowering {
     fn name(&self) -> &'static str {
         "convert_mlir_to_wat::AddiLowering"
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<arith::AddiOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
-        let op = op.as_any().downcast_ref::<arith::AddiOp>().unwrap();
+        let op = match op.as_any().downcast_ref::<arith::AddiOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
         let operation = op.operation().clone();
         let new_op = wat::AddOp::from_operation_arc(operation);
         let new_op = Shared::new(new_op.into());
@@ -40,12 +40,12 @@ impl Rewrite for FuncLowering {
     fn name(&self) -> &'static str {
         "convert_mlir_to_wat::FuncLowering"
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<func::FuncOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
-        let op = op.as_any().downcast_ref::<func::FuncOp>().unwrap();
+        let op = match op.as_any().downcast_ref::<func::FuncOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
         let operation = op.operation().clone();
         let mut new_op = wat::FuncOp::from_operation_arc(operation);
         if op.sym_visibility().is_none() {
@@ -66,14 +66,16 @@ impl Rewrite for ModuleLowering {
     fn name(&self) -> &'static str {
         "convert_mlir_to_wat::ModuleLowering"
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<ir::ModuleOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
-        let operation = op.rd().operation().clone();
+        let op = op.rd();
+        let op = match op.as_any().downcast_ref::<ir::ModuleOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
+        let operation = op.operation().clone();
         let new_op = wat::ModuleOp::from_operation_arc(operation);
         let new_op = Shared::new(new_op.into());
-        op.rd().replace(new_op.clone());
+        op.replace(new_op.clone());
         Ok(RewriteResult::Changed(ChangedOp::new(new_op)))
     }
 }
@@ -84,12 +86,12 @@ impl Rewrite for ReturnLowering {
     fn name(&self) -> &'static str {
         "convert_mlir_to_wat::ReturnLowering"
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<func::ReturnOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
-        let op = op.as_any().downcast_ref::<func::ReturnOp>().unwrap();
+        let op = match op.as_any().downcast_ref::<func::ReturnOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
         let operation = op.operation().clone();
         let new_op = wat::ReturnOp::from_operation_arc(operation);
         let new_op = Shared::new(new_op.into());

--- a/xrcf/src/convert/mod.rs
+++ b/xrcf/src/convert/mod.rs
@@ -97,18 +97,6 @@ pub trait Rewrite: Send + Sync {
     fn parallelizable(&self) -> bool {
         false
     }
-    /// Returns true if the rewrite can be applied to the given operation.
-    ///
-    /// This method is not allowed to mutate the IR.
-    ///
-    /// Note that this implementation usually will look like
-    /// ```mlir
-    /// Ok(op.as_any().is::<MyOp>())
-    /// ```
-    /// If weird behavior is encountered, ensure that the new type has set the
-    /// correct operation name. Otherwise, an object might look like is a
-    /// different type than it really is.
-    fn is_match(&self, op: &dyn Op) -> Result<bool>;
     /// Applies the rewrite to the given operation.
     ///
     /// This method is allowed to mutate the IR.
@@ -148,13 +136,10 @@ fn apply_rewrite(
         root.clone().rd().name(),
         rewrite.name()
     );
-    if rewrite.is_match(&*root.rd())? {
-        debug!("{}--> Success", spaces(indent));
-        let root_rewrite = rewrite.rewrite(root.clone())?;
-        if root_rewrite.is_changed().is_some() {
-            debug!("{}----> Changed", spaces(indent));
-            return Ok(root_rewrite);
-        }
+    let root_rewrite = rewrite.rewrite(root.clone())?;
+    if root_rewrite.is_changed().is_some() {
+        debug!("{}----> Changed", spaces(indent));
+        return Ok(root_rewrite);
     }
 
     fn finder(result: &Result<RewriteResult>) -> bool {

--- a/xrcf/src/convert/scf_to_cf.rs
+++ b/xrcf/src/convert/scf_to_cf.rs
@@ -271,14 +271,14 @@ impl Rewrite for IfLowering {
     fn name(&self) -> &'static str {
         "scf_to_cf::IfLowering"
     }
-    fn is_match(&self, op: &dyn Op) -> Result<bool> {
-        Ok(op.as_any().is::<dialect::scf::IfOp>())
-    }
     fn rewrite(&self, op: Shared<dyn Op>) -> Result<RewriteResult> {
         let op = op.rd();
         let parent = op.operation().rd().parent().expect("Expected parent");
         let parent_region = parent.rd().parent().expect("Expected parent region");
-        let op = op.as_any().downcast_ref::<dialect::scf::IfOp>().unwrap();
+        let op = match op.as_any().downcast_ref::<dialect::scf::IfOp>() {
+            Some(op) => op,
+            None => return Ok(RewriteResult::Unchanged),
+        };
 
         let (then, els) = add_blocks(op, parent_region.clone())?;
 


### PR DESCRIPTION
Basically xrcf defaults now to `matchAndRewrite` for everything.

This avoids having to type/run
```rust
op.as_any().downcast_ref::<SomeOp>()
```
twice.