### PR TITLE
Share `Block` instead of `Block.ops`

### DIFF
--- a/xrcf/src/canonicalize.rs
+++ b/xrcf/src/canonicalize.rs
@@ -46,7 +46,7 @@ impl Rewrite for DeadCodeElimination {
             Users::OpOperands(users) => {
                 if users.is_empty() {
                     let parent = operation.parent().unwrap();
-                    parent.rd().remove(readonly.operation().clone());
+                    parent.wr().remove(readonly.operation().clone());
                     Ok(RewriteResult::Changed(ChangedOp::new(op.clone())))
                 } else {
                     Ok(RewriteResult::Unchanged)

--- a/xrcf/src/convert/mlir_to_llvmir.rs
+++ b/xrcf/src/convert/mlir_to_llvmir.rs
@@ -406,8 +406,7 @@ fn set_phi_result(phi: Shared<dyn Op>, argument: &Shared<Value>) {
 
 /// Replace the only argument of the block by a `phi` instruction.
 fn insert_phi(block: Shared<Block>) {
-    let block_read = block.rd();
-    let arguments = block_read.arguments().vec();
+    let arguments = block.rd().arguments().vec();
     let mut arguments = arguments.wr();
     assert!(
         arguments.len() == 1,

--- a/xrcf/src/convert/mlir_to_llvmir.rs
+++ b/xrcf/src/convert/mlir_to_llvmir.rs
@@ -426,7 +426,7 @@ fn insert_phi(block: Shared<Block>) {
     let phi = Shared::new(phi.into());
     set_phi_result(phi.clone(), argument);
     arguments.clear();
-    block_read.insert_op(phi, 0);
+    block.wr().insert_op(phi, 0);
 }
 
 /// Remove the operands of the callers that call given block.

--- a/xrcf/src/convert/mlir_to_llvmir.rs
+++ b/xrcf/src/convert/mlir_to_llvmir.rs
@@ -462,8 +462,7 @@ fn one_child_block_has_argument(op: &dyn Op) -> Result<bool> {
         return Ok(false);
     }
     for block in operation.rd().blocks().into_iter() {
-        let block = block.rd();
-        let has_argument = !block.arguments().vec().rd().is_empty();
+        let has_argument = !block.rd().arguments().vec().rd().is_empty();
         if has_argument {
             return Ok(true);
         }
@@ -484,8 +483,7 @@ impl Rewrite for MergeLowering {
         }
         let blocks = op.rd().operation().rd().region().unwrap().rd().blocks();
         for block in blocks.into_iter() {
-            let block_read = block.rd();
-            let has_argument = !block_read.arguments().vec().rd().is_empty();
+            let has_argument = !block.rd().arguments().vec().rd().is_empty();
             if has_argument {
                 insert_phi(block.clone());
                 remove_caller_operands(block.clone());

--- a/xrcf/src/convert/scf_to_cf.rs
+++ b/xrcf/src/convert/scf_to_cf.rs
@@ -73,7 +73,7 @@ fn branch_op(after: Shared<Block>) -> Shared<dyn Op> {
 
 /// Add a `cf.br` to the end of `block` with destination `after`.
 fn add_branch_to_after(block: Shared<Block>, after: Shared<Block>) {
-    let mut ops = block.rd().ops.clone();
+    let ops = &mut block.wr().ops;
     let ops_clone = ops.clone();
     let last_op = ops_clone.last().unwrap();
     let last_op = last_op.rd();
@@ -117,11 +117,10 @@ fn move_successors_to_exit_block(op: &dialect::scf::IfOp, exit_block: Shared<Blo
         .rd()
         .index_of(&op.operation().rd())
         .expect("Expected index");
-    let mut ops = if_op_parent.rd().ops.clone();
+    let ops = &mut if_op_parent.wr().ops;
     let return_ops = ops[if_op_index + 1..].to_vec();
     for op in return_ops.iter() {
-        let op = op.rd();
-        op.set_parent(exit_block.clone());
+        op.rd().set_parent(exit_block.clone());
     }
     exit_block.wr().ops = return_ops;
     ops.drain(if_op_index + 1..);

--- a/xrcf/src/convert/scf_to_cf.rs
+++ b/xrcf/src/convert/scf_to_cf.rs
@@ -73,8 +73,7 @@ fn branch_op(after: Shared<Block>) -> Shared<dyn Op> {
 
 /// Add a `cf.br` to the end of `block` with destination `after`.
 fn add_branch_to_after(block: Shared<Block>, after: Shared<Block>) {
-    let ops = block.rd().ops();
-    let mut ops = ops.wr();
+    let mut ops = block.rd().ops.clone();
     let ops_clone = ops.clone();
     let last_op = ops_clone.last().unwrap();
     let last_op = last_op.rd();
@@ -118,14 +117,13 @@ fn move_successors_to_exit_block(op: &dialect::scf::IfOp, exit_block: Shared<Blo
         .rd()
         .index_of(&op.operation().rd())
         .expect("Expected index");
-    let ops = if_op_parent.rd().ops();
-    let mut ops = ops.wr();
+    let mut ops = if_op_parent.rd().ops.clone();
     let return_ops = ops[if_op_index + 1..].to_vec();
     for op in return_ops.iter() {
         let op = op.rd();
         op.set_parent(exit_block.clone());
     }
-    exit_block.wr().set_ops(Shared::new(return_ops.into()));
+    exit_block.wr().ops = return_ops;
     ops.drain(if_op_index + 1..);
     Ok(())
 }
@@ -149,9 +147,7 @@ fn add_merge_block(
     merge_op.set_dest(operand);
 
     let merge_op: Shared<dyn Op> = Shared::new(merge_op.into());
-    merge
-        .wr()
-        .set_ops(Shared::new(vec![merge_op.clone()].into()));
+    merge.wr().ops = vec![merge_op.clone()];
     Ok((merge, merge_block_arguments))
 }
 

--- a/xrcf/src/dialect/func/op.rs
+++ b/xrcf/src/dialect/func/op.rs
@@ -249,12 +249,11 @@ impl FuncOp {
                 panic!("Expected region to be empty");
             }
             let ops = vec![op.clone()];
-            let ops = Shared::new(ops.into());
             let region = Region::default();
             let without_parent = region.add_empty_block();
             let region = Shared::new(region.into());
             let block = without_parent.set_parent(Some(region.clone()));
-            block.wr().set_ops(ops);
+            block.wr().ops = ops;
             operation.wr().set_region(Some(region));
         } else {
             ops.last().unwrap().rd().insert_after(op.clone());

--- a/xrcf/src/frontend/parser.rs
+++ b/xrcf/src/frontend/parser.rs
@@ -316,8 +316,7 @@ impl<T: ParserDispatch> Parser<T> {
             (label, values)
         };
 
-        let mut ops = vec![];
-        let block = Block::new(label, arguments.clone(), ops.clone(), parent);
+        let block = Block::new(label, arguments.clone(), vec![], parent);
         let block = Shared::new(block.into());
         replace_block_labels(block.clone());
         for argument in arguments.vec().rd().iter() {
@@ -330,9 +329,9 @@ impl<T: ParserDispatch> Parser<T> {
         while !self.is_region_end() && !self.is_block_definition() {
             let parent = Some(block.clone());
             let op = T::parse_op(self, parent)?;
-            ops.push(op.clone());
+            block.wr().ops.push(op.clone());
         }
-        if ops.is_empty() {
+        if block.rd().ops.is_empty() {
             let token = self.peek();
             let msg = self.error(token, "Could not find operations in block");
             return Err(anyhow::anyhow!(msg));

--- a/xrcf/src/ir/module.rs
+++ b/xrcf/src/ir/module.rs
@@ -57,7 +57,7 @@ impl ModuleOp {
             Some(block) => block,
             None => return Err(anyhow::anyhow!("Expected 1 block in module, got 0")),
         };
-        match block.rd().ops().rd().first() {
+        match block.rd().ops.first() {
             #[allow(clippy::needless_return)]
             None => return Err(anyhow::anyhow!("Expected 1 op, got 0")),
             #[allow(clippy::needless_return)]

--- a/xrcf/src/ir/op.rs
+++ b/xrcf/src/ir/op.rs
@@ -129,7 +129,7 @@ pub trait Op: Send + Sync {
         };
         let later = operation.clone();
         earlier.rd().set_parent(parent.clone());
-        parent.rd().insert_before(earlier, later);
+        parent.wr().insert_before(earlier, later);
     }
     /// Insert `later` after `self` inside `self`'s parent block.
     ///
@@ -142,13 +142,13 @@ pub trait Op: Send + Sync {
         };
         let earlier = operation.clone();
         later.rd().set_parent(parent.clone());
-        parent.rd().insert_after(earlier, later);
+        parent.wr().insert_after(earlier, later);
     }
     /// Remove the operation from its parent block.
     fn remove(&self) {
         let operation = self.operation();
         let parent = operation.rd().parent().expect("no parent");
-        parent.rd().remove(operation.clone());
+        parent.wr().remove(operation.clone());
     }
     /// Replace self with `new`.
     ///
@@ -172,7 +172,7 @@ pub trait Op: Send + Sync {
         // Root ops do not have a parent, so in that case we don't need to
         // update the parent.
         if let Some(parent) = self.operation().rd().parent() {
-            parent.rd().replace(self.operation().clone(), new.clone())
+            parent.wr().replace(self.operation().clone(), new.clone())
         }
     }
     /// Return ops that are children of this op (inside blocks that are inside

--- a/xrcf/src/ir/operation.rs
+++ b/xrcf/src/ir/operation.rs
@@ -322,7 +322,7 @@ impl Operation {
     pub fn predecessors(&self) -> Vec<Shared<dyn Op>> {
         let parent = self.parent().expect("no parent");
         match parent.clone().rd().index_of(self) {
-            Some(index) => parent.rd().ops().rd()[..index].to_vec(),
+            Some(index) => parent.rd().ops[..index].to_vec(),
             None => {
                 panic!(
                     "Expected index. Is the parent set correctly for the following op?\n{}",
@@ -334,7 +334,7 @@ impl Operation {
     pub fn successors(&self) -> Vec<Shared<dyn Op>> {
         let parent = self.parent().expect("no parent");
         match parent.clone().rd().index_of(self) {
-            Some(index) => parent.rd().ops().rd()[index + 1..].to_vec(),
+            Some(index) => parent.rd().ops[index + 1..].to_vec(),
             None => {
                 panic!(
                     "Expected index. Is the parent set correctly for the following op?\n{}",

--- a/xrcf/src/ir/region.rs
+++ b/xrcf/src/ir/region.rs
@@ -107,7 +107,7 @@ fn set_fresh_ssa_names(prefix: &str, blocks: &[Shared<Block>]) {
     // SSA names stay in scope until the end of the region I think.
     let mut name_index: usize = 0;
     for block in blocks.iter() {
-        for op in block.rd().ops().rd().iter() {
+        for op in block.rd().ops.iter() {
             for result in op.rd().operation().rd().results() {
                 if let Value::OpResult(op_result) = &mut *result.wr() {
                     let name = format!("{prefix}{name_index}");
@@ -135,7 +135,7 @@ impl Region {
     pub fn ops(&self) -> Vec<Shared<dyn Op>> {
         let mut result = Vec::new();
         for block in self.blocks().into_iter() {
-            for op in block.rd().ops().rd().iter() {
+            for op in block.rd().ops.iter() {
                 result.push(op.clone());
             }
         }
@@ -178,8 +178,7 @@ impl Region {
         let prefixes = self
             .block(0)
             .rd()
-            .ops()
-            .rd()
+            .ops
             .first()
             .unwrap()
             .rd()

--- a/xrcf/src/ir/region.rs
+++ b/xrcf/src/ir/region.rs
@@ -175,14 +175,7 @@ impl Region {
         // the module have to be rewritten for the output to be correct so will
         // know the right prefixes, see also the [Op::prefixes] docstring for
         // more information.
-        let prefixes = self
-            .block(0)
-            .rd()
-            .ops
-            .first()
-            .unwrap()
-            .rd()
-            .prefixes();
+        let prefixes = self.block(0).rd().ops.first().unwrap().rd().prefixes();
         set_fresh_argument_names(prefixes.argument, &blocks);
         set_fresh_block_labels(prefixes.block, &blocks);
         set_fresh_ssa_names(prefixes.ssa, &blocks);

--- a/xrcf/src/ir/value.rs
+++ b/xrcf/src/ir/value.rs
@@ -460,9 +460,9 @@ impl Value {
         } else {
             panic!("BlockArgument {arg} has no parent operation");
         };
-        let mut ops = parent.rd().ops().rd().clone();
+        let mut ops = parent.rd().ops.clone();
         for successor in parent.rd().successors().unwrap().iter() {
-            ops.extend(successor.rd().ops().rd().clone());
+            ops.extend(successor.rd().ops.clone());
         }
         self.find_users(&ops)
     }

--- a/xrcf/src/shared.rs
+++ b/xrcf/src/shared.rs
@@ -57,10 +57,10 @@ pub trait SharedExt<T: ?Sized> {
 
 impl<T: ?Sized> SharedExt<T> for Shared<T> {
     fn rd(&self) -> parking_lot::RwLockReadGuard<T> {
-        self.read()
+        self.try_read().unwrap()
     }
     fn wr(&self) -> parking_lot::RwLockWriteGuard<T> {
-        self.write()
+        self.try_write().unwrap()
     }
 }
 

--- a/xrcf/src/shared.rs
+++ b/xrcf/src/shared.rs
@@ -57,10 +57,10 @@ pub trait SharedExt<T: ?Sized> {
 
 impl<T: ?Sized> SharedExt<T> for Shared<T> {
     fn rd(&self) -> parking_lot::RwLockReadGuard<T> {
-        self.try_read().unwrap()
+        self.read()
     }
     fn wr(&self) -> parking_lot::RwLockWriteGuard<T> {
-        self.try_write().unwrap()
+        self.write()
     }
 }
 


### PR DESCRIPTION
Removes one `Shared` (`Arc`) to simplify the API and replaces trivial getters and setters by `pub` (#44).
```diff
  pub struct Block {
      pub label: BlockName,
      arguments: Values,
-     ops: Shared<Vec<Shared<dyn Op>>>,
+     pub ops: Vec<Shared<dyn Op>>,
      parent: Option<Shared<Region>>,
  }
```