### PR TITLE
Remove getter and setter methods from TransformOptions

### DIFF
--- a/arnoldc/src/main.rs
+++ b/arnoldc/src/main.rs
@@ -122,10 +122,10 @@ mod tests {
         let passes = Passes::from_convert_vec(args.clone());
         let mut options = TransformOptions::from_passes(passes.clone());
         if args.contains(&"--print-ir-before-all") {
-            options.set_print_ir_before_all(true);
+            options.print_ir_before_all = true;
         }
         if let Some(out) = out {
-            options.set_writer(out);
+            options.writer = out;
         }
         let result = parse_and_transform(input_text, &options)?;
         Ok(result)

--- a/xrcf/src/transform.rs
+++ b/xrcf/src/transform.rs
@@ -105,8 +105,8 @@ pub struct TransformOptions {
     /// would be useful. `print-ir-before-all` is useful to see the IR after
     /// parsing, but seeing the IR after the last pass is already the final
     /// output.
-    print_ir_before_all: bool,
-    writer: Shared<dyn std::io::Write + Send>,
+    pub print_ir_before_all: bool,
+    pub writer: Shared<dyn std::io::Write + Send>,
 }
 
 impl TransformOptions {
@@ -125,17 +125,8 @@ impl TransformOptions {
             writer: Shared::new(std::io::stderr().into()),
         }
     }
-    pub fn print_ir_before_all(&self) -> bool {
-        self.print_ir_before_all
-    }
     pub fn passes(&self) -> &Passes {
         &self.passes
-    }
-    pub fn set_print_ir_before_all(&mut self, print_ir_before_all: bool) {
-        self.print_ir_before_all = print_ir_before_all;
-    }
-    pub fn set_writer(&mut self, writer: Shared<dyn std::io::Write + Send>) {
-        self.writer = writer;
     }
 }
 
@@ -225,7 +216,7 @@ pub fn transform<T: TransformDispatch>(
 ) -> Result<RewriteResult> {
     let mut result = RewriteResult::Unchanged;
     for pass in options.passes().vec() {
-        if options.print_ir_before_all() {
+        if options.print_ir_before_all {
             let op = op.rd();
             writeln!(
                 &mut *options.writer.wr(),


### PR DESCRIPTION
This commit removes the getter and setter methods for print_ir_before_all and makes the print_ir_before_all field public. It also removes the setter method for write and makes the writer field public. Reference to issue #44 