### PR TITLE
Remove value getter/setter from OpOperand

### DIFF
--- a/arnoldc/src/arnold_to_mlir.rs
+++ b/arnoldc/src/arnold_to_mlir.rs
@@ -278,7 +278,7 @@ impl Rewrite for PrintLowering {
         new_op.set_parent(op.operation().rd().parent().clone().unwrap());
 
         let operand = op.text();
-        let value = operand.rd().value();
+        let value = operand.rd().value.clone();
         match &*value.rd() {
             // printf("some text")
             Value::Constant(constant) => {

--- a/xrcf/src/convert/mlir_to_llvmir.rs
+++ b/xrcf/src/convert/mlir_to_llvmir.rs
@@ -138,7 +138,7 @@ impl Rewrite for BranchLowering {
         };
         let valid_values = op.operation().rd().operands().into_iter().all(|operand| {
             let operand = operand.rd();
-            let value = operand.value();
+            let value = &operand.value;
             let value = value.rd();
             matches!(&*value, Value::BlockLabel(_) | Value::BlockPtr(_))
         });
@@ -346,7 +346,7 @@ fn verify_argument_pairs(pairs: &[(Shared<OpOperand>, Shared<Block>)]) {
     }
     let mut typ: Option<Shared<dyn Type>> = None;
     for (op_operand, _) in pairs.iter() {
-        let value_typ = op_operand.rd().value().rd().typ().unwrap();
+        let value_typ = op_operand.rd().value.rd().typ().unwrap();
         if let Some(typ) = &typ {
             let typ = typ.rd().to_string();
             let value_typ = value_typ.rd().to_string();
@@ -397,7 +397,7 @@ fn set_phi_result(phi: Shared<dyn Op>, argument: &Shared<Value>) {
 
         for user in users.iter() {
             let mut user = user.wr();
-            user.set_value(new.clone());
+            user.value = new.clone();
         }
     } else {
         panic!("Expected a block argument");
@@ -557,7 +557,7 @@ impl Rewrite for StoreLowering {
         let mut new_op = targ3t::llvmir::StoreOp::from_operation_arc(operation.clone());
         {
             let op_operand = op.value();
-            let value = op_operand.rd().value();
+            let value = &op_operand.rd().value;
             let value_typ = value.rd().typ().unwrap();
             let value_typ = value_typ.rd();
             let value_typ = value_typ

--- a/xrcf/src/convert/scf_to_cf.rs
+++ b/xrcf/src/convert/scf_to_cf.rs
@@ -248,7 +248,7 @@ fn add_blocks(
             let arg = merge_block_arguments[i].clone();
             for user in users.iter() {
                 let mut user = user.wr();
-                user.set_value(arg.clone());
+                user.value = arg.clone();
             }
         }
         merge

--- a/xrcf/src/dialect/experimental/op.rs
+++ b/xrcf/src/dialect/experimental/op.rs
@@ -30,7 +30,7 @@ impl PrintfOp {
     pub fn text(&self) -> StringAttr {
         let operands = self.operation.rd().operand(0);
         let operand = operands.expect("no operand");
-        let value = operand.rd().value();
+        let value = &operand.rd().value;
         let value = value.rd();
         match &*value {
             Value::Constant(constant) => constant

--- a/xrcf/src/frontend/parser.rs
+++ b/xrcf/src/frontend/parser.rs
@@ -227,12 +227,12 @@ fn replace_block_labels(block: Shared<Block>) {
         for op in predecessor.rd().ops.iter() {
             for operand in op.rd().operation().rd().operands().into_iter() {
                 let mut operand = operand.wr();
-                if let Value::BlockLabel(curr) = &*operand.value().rd() {
+                if let Value::BlockLabel(curr) = &*operand.value.clone().rd() {
                     if curr.name() == label {
                         let block_ptr = BlockPtr::new(block.clone());
                         let block_ptr = Value::BlockPtr(block_ptr);
                         let block_ptr = Shared::new(block_ptr.into());
-                        operand.set_value(block_ptr.clone());
+                        operand.value = block_ptr.clone();
                     }
                 }
             }

--- a/xrcf/src/ir/block.rs
+++ b/xrcf/src/ir/block.rs
@@ -84,7 +84,7 @@ impl Block {
         for p in self.predecessors().expect("no predecessors") {
             for op in p.rd().ops.iter() {
                 for operand in op.rd().operation().rd().operands().into_iter() {
-                    match &*operand.rd().value().rd() {
+                    match &*operand.rd().value.rd() {
                         Value::BlockPtr(block_ptr) => {
                             let current = block_ptr.block();
                             let current = &*current.rd();

--- a/xrcf/src/ir/op_operand.rs
+++ b/xrcf/src/ir/op_operand.rs
@@ -16,7 +16,7 @@ use std::fmt::Formatter;
 use std::sync::Arc;
 
 pub struct OpOperand {
-    value: Shared<Value>,
+    pub value: Shared<Value>,
 }
 
 impl OpOperand {
@@ -29,20 +29,14 @@ impl OpOperand {
         OpOperand { value }
     }
     pub fn name(&self) -> String {
-        self.value().rd().name().expect("no name")
-    }
-    pub fn value(&self) -> Shared<Value> {
-        self.value.clone()
-    }
-    pub fn set_value(&mut self, value: Shared<Value>) {
-        self.value = value;
+        self.value.rd().name().expect("no name")
     }
     /// If this `OpOperand` is the result of an operation, return the operation
     /// that defines it.
     ///
     /// Returns `None` if the operand is not a [Value::OpResult].
     pub fn defining_op(&self) -> Option<Shared<dyn Op>> {
-        match &*self.value().rd() {
+        match &*self.value.rd() {
             Value::BlockArgument(_) => None,
             Value::BlockLabel(_) => None,
             Value::BlockPtr(_) => None,

--- a/xrcf/src/ir/value.rs
+++ b/xrcf/src/ir/value.rs
@@ -445,7 +445,7 @@ impl Value {
         let mut out = Vec::new();
         for op in ops.iter() {
             for operand in op.rd().operation().rd().operands().into_iter() {
-                let value = operand.rd().value();
+                let value = &operand.rd().value;
                 if std::ptr::eq(&*value.rd() as *const Value, self as *const Value) {
                     out.push(operand.clone());
                 }

--- a/xrcf/src/targ3t/llvmir/op.rs
+++ b/xrcf/src/targ3t/llvmir/op.rs
@@ -27,7 +27,7 @@ const PREFIXES: Prefixes = Prefixes {
 
 /// Display an operand LLVMIR style (e.g., `i32 8`, `i32 %0`, or `label %exit`).
 fn display_operand(f: &mut Formatter<'_>, operand: &Shared<OpOperand>) -> std::fmt::Result {
-    match &*operand.rd().value().rd() {
+    match &*operand.rd().value.rd() {
         Value::BlockArgument(block_arg) => {
             let name = match &block_arg.name {
                 BlockArgumentName::Anonymous => panic!("Expected a named block argument"),
@@ -60,7 +60,7 @@ fn display_operand(f: &mut Formatter<'_>, operand: &Shared<OpOperand>) -> std::f
         }
         _ => panic!(
             "Unexpected operand value type for {}",
-            operand.rd().value().rd()
+            operand.rd().value.rd()
         ),
     }
 }
@@ -118,7 +118,7 @@ pub struct AllocaOp {
 
 impl AllocaOp {
     pub fn array_size(&self) -> Arc<dyn Attribute> {
-        match &*self.operation().rd().operand(0).unwrap().rd().value().rd() {
+        match &*self.operation().rd().operand(0).unwrap().rd().value.rd() {
             Value::Constant(constant) => constant.value().clone(),
             _ => panic!("Unexpected"),
         }
@@ -450,7 +450,7 @@ impl Op for PhiOp {
         let mut texts = vec![];
         for (value, block) in pairs {
             let value = value.rd();
-            let value = value.value();
+            let value = &value.value;
             let value = value.rd();
             let value = if let Value::Constant(constant) = &*value {
                 // Drop type information.


### PR DESCRIPTION
This commit removes the value getter/setter methods and makes the value field public. It also updates all previous usage of the getter/setter. References issue #44